### PR TITLE
Adding CI step to tag released images

### DIFF
--- a/.github/workflows/tag-release-images.yml
+++ b/.github/workflows/tag-release-images.yml
@@ -15,7 +15,7 @@ name: Tag Release Images
 
 on:
   release:
-    types: [edited]
+    types: [published]
 
 permissions:
   contents: "read" # Needed for checkout

--- a/.github/workflows/tag-release-images.yml
+++ b/.github/workflows/tag-release-images.yml
@@ -15,7 +15,7 @@ name: Tag Release Images
 
 on:
   release:
-    types: [published]
+    types: [edited]
 
 permissions:
   contents: "read" # Needed for checkout

--- a/.github/workflows/tag-release-images.yml
+++ b/.github/workflows/tag-release-images.yml
@@ -1,5 +1,18 @@
 name: Tag Release Images
 
+# --- Testing Instructions ---
+# To test this workflow manually:
+# 1. Temporarily change the trigger type below from `published` to `created` or `edited`.
+#    For example: `types: [edited]`
+# 2. Commit and push the change to a test branch.
+# 3. Create a draft release using the GitHub CLI:
+#    gh release create v0.0.0-test --draft --generate-notes
+# 4. If using `types: [edited]`, edit the draft release via the GitHub UI.
+# 5. Observe the workflow run in the Actions tab for your test branch/commit.
+# 6. Remember to revert the `types` change in the workflow file afterwards.
+# 7. Prior to running, make sure there are docker images pushed for this commit.
+# --- End Testing Instructions ---
+
 on:
   release:
     types: [published]

--- a/.github/workflows/tag-release-images.yml
+++ b/.github/workflows/tag-release-images.yml
@@ -1,0 +1,65 @@
+name: Tag Release Images
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: "read" # Needed for checkout
+  packages: "write" # Needed to push docker images to ghcr.io
+
+concurrency:
+  group: tag-release-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  publish:
+    name: Tag Release Images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }} 
+
+      - name: Set up build dependencies (crane)
+        working-directory: build
+        run: make install-crane
+
+      - name: Authenticate crane to GHCR
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | ./build/bin/crane auth login ghcr.io -u "${{ github.actor }}" --password-stdin
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Prepare and Tag Images
+        env:
+          SOURCE_COMMIT_SHA: ${{ github.event.release.target_commitish }}
+          GIT_REF: ${{ github.ref }} 
+        run: |
+          echo "Determining base image names..."
+          make -C build docker/.remote-image-names
+          echo "Base image names generated in build/docker/.remote-image-names"
+          cat build/docker/.remote-image-names
+          
+          echo "Reading stable branches..."
+          build/scripts/read-build-config.sh --key stable_branches > /tmp/stable_branches.txt
+          echo "Stable branches: $(cat /tmp/stable_branches.txt)"
+          
+          echo "Calculating target tags (always including latest)..."
+          build/scripts/resolve-docker-tags.sh \
+            --commit-sha "$SOURCE_COMMIT_SHA" \
+            --git-ref "$GIT_REF" \
+            --stable-branches "$(cat /tmp/stable_branches.txt)" \
+            --latest > /tmp/target-tags.txt
+          
+          echo "Raw target tags calculated:"
+          cat /tmp/target-tags.txt
+          
+          echo "Tagging remote images..."
+          build/scripts/tag-remote-images.sh \
+            --source-commit-sha "$SOURCE_COMMIT_SHA" \
+            --target-tags "$(cat /tmp/target-tags.txt)" \
+            --remote-images-file build/docker/.remote-image-names
+          
+          echo "Image tagging process finished."

--- a/build/Makefile
+++ b/build/Makefile
@@ -237,6 +237,24 @@ docker/.remote-images: $(remote_image_targets)
 	@rm -f docker/remote-images.tmp
 	@echo "Remote images pushed: $?"
 
+# Target to generate a file containing the list of remote image base names
+# without building/pushing the images.
+docker/.remote-image-names: .git-meta/repo-name .git-meta/repo-namespace
+	@echo "Generating list of remote image names to $@..."
+	@rm -f $@ $@.tmp
+	@touch $@.tmp
+	$(eval docker_push_registries := $(call read_config,build.cfg,docker_push_registries))
+	$(eval binaries := $(notdir $(wildcard ../cmd/*)))
+	@$(foreach registry_name,$(subst $(comma), ,$(docker_push_registries)), \
+		$(eval registry := $(call read_config,build.cfg,docker_$(registry_name)_registry)) \
+		$(foreach binary,$(binaries), \
+			echo "$(registry)/$(shell cat .git-meta/repo-namespace)/$(shell cat .git-meta/repo-name)-$(binary)" >> $@.tmp; \
+		) \
+	)
+	@sort -u $@.tmp > $@
+	@rm -f $@.tmp
+	@echo "List of remote image names written to $@"
+
 .PHONY: clean docker/clean dist/clean
 
 docker/clean:

--- a/build/scripts/tag-remote-images.sh
+++ b/build/scripts/tag-remote-images.sh
@@ -1,5 +1,64 @@
 #!/usr/bin/env bash
 
+# --- Usage Examples ---
+#
+# This script retags an existing Docker image (identified by its source commit SHA tag)
+# with one or more new target tags.
+#
+# Prerequisites:
+# - The 'crane' tool must be installed (e.g., via 'make -C build install-crane')
+# - For actual tagging (not --noop), crane needs registry authentication.
+#
+# Example 1: Using direct image list (--remote-images) and --noop
+#
+#   build/scripts/tag-remote-images.sh \
+#     --source-commit-sha "abcdef1234567" \
+#     --target-tags "v1.2.3 v1.2-latest latest" \
+#     --remote-images $'ghcr.io/owner/repo-server\nghcr.io/owner/repo-jobs' \
+#     --noop
+#
+# Expected Output (Example 1):
+#
+#   Info: Using remote images provided via --remote-images argument.
+#   --- Reading Configuration ---
+#   Using stable branches: <branches_from_build.cfg>
+#
+#   --- Target Tags ---
+#   Provided target tags: v1.2.3 v1.2-latest latest
+#
+#   --- Tagging Remote Images ---
+#   *** NOOP mode enabled: Printing commands instead of executing them ***
+#   Source image tag: git-commit-abcdef1
+#   Reading base images from --remote-images argument...
+#   Processing base image: ghcr.io/owner/repo-server
+#     [NOOP] Would run: '<path_to_crane>' tag 'ghcr.io/owner/repo-server:git-commit-abcdef1' 'v1.2.3'
+#     [NOOP] Would run: '<path_to_crane>' tag 'ghcr.io/owner/repo-server:git-commit-abcdef1' 'v1.2-latest'
+#     [NOOP] Would run: '<path_to_crane>' tag 'ghcr.io/owner/repo-server:git-commit-abcdef1' 'latest'
+#   
+#   Processing base image: ghcr.io/owner/repo-jobs
+#     [NOOP] Would run: '<path_to_crane>' tag 'ghcr.io/owner/repo-jobs:git-commit-abcdef1' 'v1.2.3'
+#     [NOOP] Would run: '<path_to_crane>' tag 'ghcr.io/owner/repo-jobs:git-commit-abcdef1' 'v1.2-latest'
+#     [NOOP] Would run: '<path_to_crane>' tag 'ghcr.io/owner/repo-jobs:git-commit-abcdef1' 'latest'
+#   
+#   --- Tagging Summary ---
+#   NOOP mode finished. No changes were made.
+#
+# Example 2: Using image file (--remote-images-file) and actual execution
+#   # Assume /tmp/images.txt contains:
+#   # ghcr.io/owner/repo-server
+#   # ghcr.io/owner/repo-jobs
+#
+#   echo $'ghcr.io/owner/repo-server\nghcr.io/owner/repo-jobs' > /tmp/images.txt
+#
+#   build/scripts/tag-remote-images.sh \
+#     --source-commit-sha "abcdef1234567" \
+#     --target-tags "v1.2.3" \
+#     --remote-images-file /tmp/images.txt
+#
+#   # (Ensure crane is authenticated before running without --noop)
+#
+# --- End Usage Examples ---
+
 # This script tags existing remote Docker images using the crane tool.
 # It reads a list of base image names (e.g., ghcr.io/namespace/repo-app)
 # from a specified file. It determines the target tags based on the
@@ -32,7 +91,9 @@ usage() {
   echo "  --target-tags \"<tags>\"      A space-separated list of tags to apply."
   echo ""
   echo "Options:"
-  echo "  --remote-images-file <path> Path to the file containing base image names (default: ${DEFAULT_REMOTE_IMAGES_FILE})"
+  echo "  --remote-images-file <path> Path to the file containing base image names (use this OR --remote-images)."
+  echo "                              (default: ${DEFAULT_REMOTE_IMAGES_FILE} if neither option is specified)"
+  echo "  --remote-images <images>    Newline-separated string containing base image names (use this OR --remote-images-file)."
   echo "  --noop                        Print the crane commands instead of executing them."
   echo "  -h, --help                    Show this help message"
 }
@@ -51,7 +112,8 @@ read_config() {
 }
 
 # --- Argument Parsing ---
-REMOTE_IMAGES_FILE="${DEFAULT_REMOTE_IMAGES_FILE}"
+REMOTE_IMAGES_FILE="" # Default to empty, will use default path later if needed
+REMOTE_IMAGES_STRING="" # New variable for direct image list
 SOURCE_COMMIT_SHA=""
 TARGET_TAGS=""
 NOOP=false
@@ -60,6 +122,10 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --remote-images-file)
       REMOTE_IMAGES_FILE="$2"
+      shift 2
+      ;;
+    --remote-images) # New option
+      REMOTE_IMAGES_STRING="$2"
       shift 2
       ;;
     --source-commit-sha)
@@ -99,10 +165,28 @@ if [[ -z "$TARGET_TAGS" ]]; then
   exit 1
 fi
 
+# Validate remote image input source
+if [[ -n "$REMOTE_IMAGES_STRING" && -n "$REMOTE_IMAGES_FILE" ]]; then
+    echo "Error: Cannot use both --remote-images and --remote-images-file options." >&2
+    usage
+    exit 1
+elif [[ -z "$REMOTE_IMAGES_STRING" && -z "$REMOTE_IMAGES_FILE" ]]; then
+    # If neither is provided, use the default file path
+    REMOTE_IMAGES_FILE="${DEFAULT_REMOTE_IMAGES_FILE}"
+    echo "Info: Neither --remote-images nor --remote-images-file specified. Using default file: ${REMOTE_IMAGES_FILE}" >&2
+elif [[ -n "$REMOTE_IMAGES_STRING" ]]; then
+    echo "Info: Using remote images provided via --remote-images argument." >&2
+    # Clear REMOTE_IMAGES_FILE just in case it was set to default initially but --remote-images was also given
+    REMOTE_IMAGES_FILE=""
+else # Only REMOTE_IMAGES_FILE is set (explicitly)
+    echo "Info: Using remote images file specified via --remote-images-file: ${REMOTE_IMAGES_FILE}" >&2
+fi
+
 # --- Derive Short SHAs ---
 SHORT_SOURCE_COMMIT_SHA="${SOURCE_COMMIT_SHA:0:7}"
 
-if [[ ! -f "$REMOTE_IMAGES_FILE" ]]; then
+# Validate file existence only if using file input
+if [[ -n "$REMOTE_IMAGES_FILE" && ! -f "$REMOTE_IMAGES_FILE" ]]; then
     echo "Error: Remote images file not found: ${REMOTE_IMAGES_FILE}" >&2
     exit 1
 fi
@@ -143,13 +227,15 @@ if [[ "$NOOP" == "true" ]]; then
 fi
 source_image_tag="git-commit-${SHORT_SOURCE_COMMIT_SHA}"
 echo "Source image tag: ${source_image_tag}"
-echo "Reading base images from: ${REMOTE_IMAGES_FILE}"
 
 tagging_errors=0
-while IFS= read -r base_image || [[ -n "$base_image" ]]; do
+
+# --- Process Base Images ---
+process_base_image() {
+    local base_image="$1"
     source_image="${base_image}:${source_image_tag}"
     if [[ -z "$base_image" ]]; then
-        continue # Skip empty lines
+        return # Skip empty lines
     fi
 
     echo "Processing base image: ${base_image}"
@@ -165,13 +251,30 @@ while IFS= read -r base_image || [[ -n "$base_image" ]]; do
                 echo "    Success."
             else
                 echo "    Error: Failed to apply tag ${target_tag} to ${base_image} (Source SHA: ${SHORT_SOURCE_COMMIT_SHA}). Check crane output above." >&2
-                ((tagging_errors++))
+                tagging_errors=$((tagging_errors + 1)) # Use arithmetic expansion
             fi
         fi
     done
     echo ""
+}
 
-done < "${REMOTE_IMAGES_FILE}"
+# Choose input source based on validation logic result
+if [[ -n "$REMOTE_IMAGES_STRING" ]]; then
+    echo "Reading base images from --remote-images argument..."
+    # Use a while loop to read newline-separated images from the string
+    echo "${REMOTE_IMAGES_STRING}" | while IFS= read -r image_line || [[ -n "$image_line" ]]; do
+        process_base_image "$image_line"
+    done
+elif [[ -n "$REMOTE_IMAGES_FILE" ]]; then
+    echo "Reading base images from file: ${REMOTE_IMAGES_FILE}"
+    while IFS= read -r image_line || [[ -n "$image_line" ]]; do
+       process_base_image "$image_line"
+    done < "${REMOTE_IMAGES_FILE}"
+else
+    # This case should ideally not be reached due to earlier validation, but added for safety
+    echo "Error: No source for remote images specified or determined." >&2
+    exit 1
+fi
 
 echo "--- Tagging Summary ---"
 if [[ "$NOOP" == "true" ]]; then


### PR DESCRIPTION
- **feat: Refactor tag-remote-images.sh to accept image list arg**
- **feat: Add docker/.remote-image-names target to Makefile**
- **ci: Add workflow to tag images on release publish**
- **docs: Update testing instructions for tag-release-images workflow**
- **Testing the release tagging flow.**
