### PR TITLE
Rename internal/diag to internal/telemetry

### DIFF
--- a/.context/instructions/create-http-clients.md
+++ b/.context/instructions/create-http-clients.md
@@ -191,7 +191,7 @@ import (
 		"net/http/httptest"
 		"testing"
 
-		"github.com/gemyago/atlacp/internal/diag"
+		"github.com/gemyago/atlacp/internal/telemetry"
 		httpservices "github.com/gemyago/golang-backend-boilerplate/internal/infrastructure/http"
 		"github.com/jaswdr/faker/v2"
 		"github.com/stretchr/testify/assert"
@@ -202,7 +202,7 @@ import (
 func TestClient_CreateResource(t *testing.T) {
 		makeMockDeps := func(t *testing.T, baseURL string) ClientDeps {
 				// Always include test name in the logger for better debugging
-				rootLogger := diag.RootTestLogger().With("test", t.Name())
+				rootLogger := telemetry.RootTestLogger().With("test", t.Name())
 				return ClientDeps{
 						ClientFactory: httpservices.NewClientFactory(httpservices.ClientFactoryDeps{
 								RootLogger: rootLogger,

--- a/.mockery.yaml
+++ b/.mockery.yaml
@@ -13,10 +13,10 @@ packages:
     interfaces:
       Handler:
         config:
-          pkgname: diag
+          pkgname: telemetry
           structname: '{{.Mock}}Slog{{.InterfaceName}}'
           filename: "mock_slog_{{snakecase .InterfaceName}}_test.go"
-          dir: 'internal/diag'
+          dir: 'internal/telemetry'
   github.com/gemyago/golang-backend-boilerplate/internal/api/http/v1controllers:
     interfaces:
       UserCommands:

--- a/cmd/mcp/http.go
+++ b/cmd/mcp/http.go
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	mcpserver "github.com/gemyago/golang-backend-boilerplate/internal/api/mcp/server"
-	"github.com/gemyago/golang-backend-boilerplate/internal/diag"
 	"github.com/gemyago/golang-backend-boilerplate/internal/system/shutdown"
+	"github.com/gemyago/golang-backend-boilerplate/internal/telemetry"
 	"github.com/spf13/cobra"
 	"go.uber.org/dig"
 	"golang.org/x/sys/unix"
@@ -37,7 +37,7 @@ func startHTTPServer(rootCtx context.Context, params startHTTPServerParams) erro
 
 		err := params.ShutdownHooks.PerformShutdown(rootCtx)
 		if err != nil {
-			rootLogger.ErrorContext(rootCtx, "Failed to shut down gracefully", diag.ErrAttr(err))
+			rootLogger.ErrorContext(rootCtx, "Failed to shut down gracefully", telemetry.ErrAttr(err))
 		}
 
 		rootLogger.InfoContext(rootCtx, "Service stopped",

--- a/cmd/mcp/stdio.go
+++ b/cmd/mcp/stdio.go
@@ -9,8 +9,8 @@ import (
 	"time"
 
 	mcpserver "github.com/gemyago/golang-backend-boilerplate/internal/api/mcp/server"
-	"github.com/gemyago/golang-backend-boilerplate/internal/diag"
 	"github.com/gemyago/golang-backend-boilerplate/internal/system/shutdown"
+	"github.com/gemyago/golang-backend-boilerplate/internal/telemetry"
 	"github.com/spf13/cobra"
 	"go.uber.org/dig"
 	"golang.org/x/sys/unix"
@@ -37,7 +37,7 @@ func startStdioServer(rootCtx context.Context, params stdioServerParams) error {
 
 		err := params.ShutdownHooks.PerformShutdown(rootCtx)
 		if err != nil {
-			rootLogger.ErrorContext(rootCtx, "Failed to shut down gracefully", diag.ErrAttr(err))
+			rootLogger.ErrorContext(rootCtx, "Failed to shut down gracefully", telemetry.ErrAttr(err))
 		}
 
 		rootLogger.InfoContext(rootCtx, "Service stopped",

--- a/cmd/server/start.go
+++ b/cmd/server/start.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/gemyago/golang-backend-boilerplate/internal/api/http"
 	"github.com/gemyago/golang-backend-boilerplate/internal/api/http/server"
-	"github.com/gemyago/golang-backend-boilerplate/internal/diag"
 	"github.com/gemyago/golang-backend-boilerplate/internal/system/shutdown"
+	"github.com/gemyago/golang-backend-boilerplate/internal/telemetry"
 	"github.com/spf13/cobra"
 	"go.uber.org/dig"
 	"golang.org/x/sys/unix"
@@ -39,7 +39,7 @@ func startServer(params startServerParams) error {
 
 		err := params.ShutdownHooks.PerformShutdown(rootCtx)
 		if err != nil {
-			rootLogger.ErrorContext(rootCtx, "Failed to shut down gracefully", diag.ErrAttr(err))
+			rootLogger.ErrorContext(rootCtx, "Failed to shut down gracefully", telemetry.ErrAttr(err))
 		}
 
 		rootLogger.InfoContext(rootCtx, "Service stopped",

--- a/doc/testing-best-practices.md
+++ b/doc/testing-best-practices.md
@@ -161,7 +161,7 @@ func TestMyService(t *testing.T) {
     // Use explicit t parameter if mock constructor requires it
     // do not use top-level t parameter
     makeMockDeps := func(t *testing.T) MyServiceDeps {
-        rootLogger := diag.RootTestLogger().With("test", t.Name())
+        rootLogger := telemetry.RootTestLogger().With("test", t.Name())
         return MyServiceDeps{
             Repository: NewMockMyRepository(t),
             RootLogger: rootLogger,

--- a/internal/AGENTS.md
+++ b/internal/AGENTS.md
@@ -74,7 +74,7 @@ Mapping from adapter specific data types to application layer data types may nee
   - [internal/infrastructure/users_repository_test.go](./infrastructure/users_repository_test.go)
 
 ## Logging and Diagnostics
-- Use log/slog via DI; no globals. See [internal/diag/slog.go](./diag/slog.go) and [internal/diag/testing.go](./diag/testing.go)
+- Use log/slog via DI; no globals. See [internal/telemetry/slog.go](./telemetry/slog.go) and [internal/telemetry/testing.go](./telemetry/testing.go)
 - Follow `.golangci.yml` slog rules; prefer context-aware logging.
 
 ## Task completion protocol

--- a/internal/api/http/middleware/correlation.go
+++ b/internal/api/http/middleware/correlation.go
@@ -4,8 +4,8 @@ import (
 	"log/slog"
 	"net/http"
 
-	"github.com/gemyago/golang-backend-boilerplate/internal/diag"
 	"github.com/gemyago/golang-backend-boilerplate/internal/system/ident"
+	"github.com/gemyago/golang-backend-boilerplate/internal/telemetry"
 )
 
 // NewCorrelationMiddleware creates a middleware that sets a correlation ID in the request context.
@@ -13,15 +13,15 @@ import (
 func NewCorrelationMiddleware(idGen ident.Generator) Middleware {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-			correlationID := req.Header.Get(diag.CorrelationIDHeader)
+			correlationID := req.Header.Get(telemetry.CorrelationIDHeader)
 			if correlationID == "" {
 				correlationID = idGen.MustNewV7().String()
 			}
-			logAttributes := diag.GetLogAttributesFromContext(req.Context())
+			logAttributes := telemetry.GetLogAttributesFromContext(req.Context())
 			logAttributes.CorrelationID = slog.StringValue(correlationID)
-			nextCtx := diag.SetLogAttributesToContext(req.Context(), logAttributes)
+			nextCtx := telemetry.SetLogAttributesToContext(req.Context(), logAttributes)
 
-			w.Header().Set(diag.CorrelationIDHeader, correlationID)
+			w.Header().Set(telemetry.CorrelationIDHeader, correlationID)
 
 			next.ServeHTTP(w, req.WithContext(nextCtx))
 		})

--- a/internal/api/http/middleware/correlation_test.go
+++ b/internal/api/http/middleware/correlation_test.go
@@ -5,8 +5,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/gemyago/golang-backend-boilerplate/internal/diag"
 	"github.com/gemyago/golang-backend-boilerplate/internal/system/ident"
+	"github.com/gemyago/golang-backend-boilerplate/internal/telemetry"
 	"github.com/jaswdr/faker/v2"
 	"github.com/stretchr/testify/assert"
 )
@@ -20,10 +20,10 @@ func TestCorrelationMiddleware(t *testing.T) {
 		mw := NewCorrelationMiddleware(idGen)
 		nextCalled := false
 		mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			logAttributes := diag.GetLogAttributesFromContext(r.Context())
+			logAttributes := telemetry.GetLogAttributesFromContext(r.Context())
 			wantCorrelationID := ident.MockGeneratorLastGenerated(idGen)
 			assert.Equal(t, wantCorrelationID.String(), logAttributes.CorrelationID.String())
-			assert.Equal(t, wantCorrelationID.String(), w.Header().Get(diag.CorrelationIDHeader))
+			assert.Equal(t, wantCorrelationID.String(), w.Header().Get(telemetry.CorrelationIDHeader))
 			nextCalled = true
 		})).ServeHTTP(res, req)
 		assert.True(t, nextCalled)
@@ -31,14 +31,14 @@ func TestCorrelationMiddleware(t *testing.T) {
 	t.Run("use existing correlation id", func(t *testing.T) {
 		wantCorrelationID := fake.UUID().V4()
 		req := httptest.NewRequest(http.MethodGet, "/something", http.NoBody)
-		req.Header.Add(diag.CorrelationIDHeader, wantCorrelationID)
+		req.Header.Add(telemetry.CorrelationIDHeader, wantCorrelationID)
 		res := httptest.NewRecorder()
 		mw := NewCorrelationMiddleware(ident.NewDefaultGenerator())
 		nextCalled := false
 		mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			logAttributes := diag.GetLogAttributesFromContext(r.Context())
+			logAttributes := telemetry.GetLogAttributesFromContext(r.Context())
 			assert.Equal(t, wantCorrelationID, logAttributes.CorrelationID.String())
-			assert.Equal(t, wantCorrelationID, w.Header().Get(diag.CorrelationIDHeader))
+			assert.Equal(t, wantCorrelationID, w.Header().Get(telemetry.CorrelationIDHeader))
 			nextCalled = true
 		})).ServeHTTP(res, req)
 		assert.True(t, nextCalled)

--- a/internal/api/http/middleware/error_handler.go
+++ b/internal/api/http/middleware/error_handler.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 
 	"github.com/gemyago/golang-backend-boilerplate/internal/app"
-	"github.com/gemyago/golang-backend-boilerplate/internal/diag"
+	"github.com/gemyago/golang-backend-boilerplate/internal/telemetry"
 )
 
 func NewAppErrorHandler(rootLogger *slog.Logger) func(w http.ResponseWriter, r *http.Request, err error) {
@@ -27,6 +27,6 @@ func NewAppErrorHandler(rootLogger *slog.Logger) func(w http.ResponseWriter, r *
 			logLevel = slog.LevelError
 			w.WriteHeader(http.StatusInternalServerError)
 		}
-		logger.Log(r.Context(), logLevel, "Failed to process request", diag.ErrAttr(err))
+		logger.Log(r.Context(), logLevel, "Failed to process request", telemetry.ErrAttr(err))
 	}
 }

--- a/internal/api/http/middleware/error_handler_test.go
+++ b/internal/api/http/middleware/error_handler_test.go
@@ -7,12 +7,12 @@ import (
 	"testing"
 
 	"github.com/gemyago/golang-backend-boilerplate/internal/app"
-	"github.com/gemyago/golang-backend-boilerplate/internal/diag"
+	"github.com/gemyago/golang-backend-boilerplate/internal/telemetry"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestNewAppErrorHandler(t *testing.T) {
-	handler := NewAppErrorHandler(diag.RootTestLogger())
+	handler := NewAppErrorHandler(telemetry.RootTestLogger())
 	t.Run("NotFoundError sets 404", func(t *testing.T) {
 		w := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, "/", nil)

--- a/internal/api/http/middleware/recover_test.go
+++ b/internal/api/http/middleware/recover_test.go
@@ -8,7 +8,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/gemyago/golang-backend-boilerplate/internal/diag"
+	"github.com/gemyago/golang-backend-boilerplate/internal/telemetry"
 	"github.com/jaswdr/faker/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -16,7 +16,7 @@ import (
 
 func TestRecover(t *testing.T) {
 	fake := faker.New()
-	rootLogger := diag.RootTestLogger()
+	rootLogger := telemetry.RootTestLogger()
 
 	t.Run("should call next", func(t *testing.T) {
 		nextCalled := true

--- a/internal/api/http/server/server.go
+++ b/internal/api/http/server/server.go
@@ -9,9 +9,9 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/gemyago/golang-backend-boilerplate/internal/diag"
 	"github.com/gemyago/golang-backend-boilerplate/internal/system/ident"
 	"github.com/gemyago/golang-backend-boilerplate/internal/system/shutdown"
+	"github.com/gemyago/golang-backend-boilerplate/internal/telemetry"
 	sloghttp "github.com/samber/slog-http"
 	"go.uber.org/dig"
 
@@ -38,7 +38,7 @@ type HTTPServerDeps struct {
 	// handler
 	Handler http.Handler
 
-	OTELMiddleware diag.OtelHTTPMiddleware
+	OTELMiddleware telemetry.OtelHTTPMiddleware
 
 	// listeningSignal is an optional channel that Start will close when the server is listening.
 	// Primarily for testing.
@@ -113,7 +113,7 @@ type RouterMiddlewareDeps struct {
 	// config
 	AccessLogsLevel string `name:"config.httpServer.accessLogsLevel"`
 
-	OTELMiddleware diag.OtelHTTPMiddleware
+	OTELMiddleware telemetry.OtelHTTPMiddleware
 	IDGen          ident.Generator
 }
 
@@ -144,7 +144,7 @@ func NewRouterMiddleware(deps RouterMiddlewareDeps) RouterMiddleware {
 			WithResponseHeader: true,
 
 			// Log handler will add those, we don't want them twice
-			// see diag/slog.go for more details
+			// see telemetry/slog.go for more details
 			WithSpanID:  false,
 			WithTraceID: false,
 		}),

--- a/internal/api/http/server/server_test.go
+++ b/internal/api/http/server/server_test.go
@@ -13,9 +13,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gemyago/golang-backend-boilerplate/internal/diag"
 	"github.com/gemyago/golang-backend-boilerplate/internal/system/ident"
 	"github.com/gemyago/golang-backend-boilerplate/internal/system/shutdown"
+	"github.com/gemyago/golang-backend-boilerplate/internal/telemetry"
 	"github.com/jaswdr/faker/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -25,7 +25,7 @@ func TestHTTPServer(t *testing.T) {
 	makeDeps := func() HTTPServerDeps {
 		port := 50000 + rand.IntN(15000)
 		return HTTPServerDeps{
-			RootLogger:    diag.RootTestLogger(),
+			RootLogger:    telemetry.RootTestLogger(),
 			Host:          "localhost",
 			Port:          port,
 			ShutdownHooks: shutdown.NewTestHooks(),
@@ -133,7 +133,7 @@ func TestRouterMiddleware(t *testing.T) {
 	t.Run("should wireup the middleware", func(t *testing.T) {
 		otelInvoked := false
 		deps := RouterMiddlewareDeps{
-			RootLogger:      diag.RootTestLogger(),
+			RootLogger:      telemetry.RootTestLogger(),
 			AccessLogsLevel: slog.LevelInfo.String(),
 			OTELMiddleware: func(h http.Handler) http.Handler {
 				otelInvoked = true

--- a/internal/api/http/server/server_testing.go
+++ b/internal/api/http/server/server_testing.go
@@ -6,12 +6,12 @@ import (
 	"net/http"
 
 	"github.com/gemyago/golang-backend-boilerplate/internal/api/http/v1routes/handlers"
-	"github.com/gemyago/golang-backend-boilerplate/internal/diag"
+	"github.com/gemyago/golang-backend-boilerplate/internal/telemetry"
 )
 
 func NewTestRootHandler() *handlers.RootHandler {
 	return NewRootHandler(RootHandlerDeps{
-		RootLogger: diag.RootTestLogger(),
+		RootLogger: telemetry.RootTestLogger(),
 		Router: NewHTTPRouter(HTTPRouterDeps{
 			Middleware: func(h http.Handler) http.Handler {
 				return h

--- a/internal/api/http/v1controllers/echo_test.go
+++ b/internal/api/http/v1controllers/echo_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/gemyago/golang-backend-boilerplate/internal/api/http/server"
 	"github.com/gemyago/golang-backend-boilerplate/internal/app"
-	"github.com/gemyago/golang-backend-boilerplate/internal/diag"
+	"github.com/gemyago/golang-backend-boilerplate/internal/telemetry"
 	"github.com/jaswdr/faker/v2"
 	"github.com/stretchr/testify/assert"
 )
@@ -19,7 +19,7 @@ func TestEcho(t *testing.T) {
 		echoService *app.EchoService
 	}
 	makeMockDeps := func() mockDeps {
-		rootLogger := diag.RootTestLogger()
+		rootLogger := telemetry.RootTestLogger()
 
 		// In real world example a mock of EchoService would be used
 		echoService := app.NewEchoService(app.EchoServiceDeps{

--- a/internal/api/http/v1controllers/pets_test.go
+++ b/internal/api/http/v1controllers/pets_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/gemyago/golang-backend-boilerplate/internal/api/http/server"
 	"github.com/gemyago/golang-backend-boilerplate/internal/api/http/v1routes/models"
 	"github.com/gemyago/golang-backend-boilerplate/internal/app"
-	"github.com/gemyago/golang-backend-boilerplate/internal/diag"
 	"github.com/gemyago/golang-backend-boilerplate/internal/infrastructure/petstore"
+	"github.com/gemyago/golang-backend-boilerplate/internal/telemetry"
 	"github.com/jaswdr/faker/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -27,7 +27,7 @@ func TestPets(t *testing.T) {
 		mockCommands := NewMockPetsCommands(t)
 		mockQueries := NewMockPetsQueries(t)
 		deps := PetsControllerDeps{
-			RootLogger:   diag.RootTestLogger(),
+			RootLogger:   telemetry.RootTestLogger(),
 			PetsCommands: mockCommands,
 			PetsQueries:  mockQueries,
 		}

--- a/internal/api/http/v1controllers/users_test.go
+++ b/internal/api/http/v1controllers/users_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/gemyago/golang-backend-boilerplate/internal/api/http/server"
 	"github.com/gemyago/golang-backend-boilerplate/internal/api/http/v1routes/models"
 	"github.com/gemyago/golang-backend-boilerplate/internal/app"
-	"github.com/gemyago/golang-backend-boilerplate/internal/diag"
+	"github.com/gemyago/golang-backend-boilerplate/internal/telemetry"
 	"github.com/jaswdr/faker/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -25,7 +25,7 @@ func TestUsers(t *testing.T) {
 		mockCommands := NewMockUserCommands(t)
 		mockQueries := NewMockUserQueries(t)
 		deps := UsersControllerDeps{
-			RootLogger:   diag.RootTestLogger(),
+			RootLogger:   telemetry.RootTestLogger(),
 			UserCommands: mockCommands,
 			UserQueries:  mockQueries,
 		}

--- a/internal/api/mcp/server/server.go
+++ b/internal/api/mcp/server/server.go
@@ -7,9 +7,9 @@ import (
 	"time"
 
 	httpserver "github.com/gemyago/golang-backend-boilerplate/internal/api/http/server"
-	"github.com/gemyago/golang-backend-boilerplate/internal/diag"
 	"github.com/gemyago/golang-backend-boilerplate/internal/system/ident"
 	"github.com/gemyago/golang-backend-boilerplate/internal/system/shutdown"
+	"github.com/gemyago/golang-backend-boilerplate/internal/telemetry"
 	"github.com/mark3labs/mcp-go/mcp"
 	mcpserver "github.com/mark3labs/mcp-go/server"
 	"go.uber.org/dig"
@@ -78,13 +78,13 @@ func NewMCPServer(deps MCPServerDeps) *MCPServer {
 			func(next mcpserver.ToolHandlerFunc) mcpserver.ToolHandlerFunc {
 				return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 					nextCtx := ctx
-					diagCtx := diag.GetLogAttributesFromContext(nextCtx)
+					diagCtx := telemetry.GetLogAttributesFromContext(nextCtx)
 
-					// We may need to revisit this. It may be so that the diag context is always set
+					// We may need to revisit this. It may be so that the telemetry context is always set
 					// for the stdio transport at least.
 					if diagCtx.CorrelationID.Kind() != slog.KindString {
 						diagCtx.CorrelationID = slog.StringValue(deps.IDGen.MustNewV7().String())
-						nextCtx = diag.SetLogAttributesToContext(nextCtx, diagCtx)
+						nextCtx = telemetry.SetLogAttributesToContext(nextCtx, diagCtx)
 					}
 
 					// It may be quite verbose and we may want to log just the "processed" part.

--- a/internal/api/mcp/server/server_test.go
+++ b/internal/api/mcp/server/server_test.go
@@ -8,9 +8,9 @@ import (
 
 	"net/http"
 
-	"github.com/gemyago/golang-backend-boilerplate/internal/diag"
 	"github.com/gemyago/golang-backend-boilerplate/internal/system/ident"
 	"github.com/gemyago/golang-backend-boilerplate/internal/system/shutdown"
+	"github.com/gemyago/golang-backend-boilerplate/internal/telemetry"
 	"github.com/jaswdr/faker/v2"
 	"github.com/mark3labs/mcp-go/mcp"
 	mcpserver "github.com/mark3labs/mcp-go/server"
@@ -22,7 +22,7 @@ func TestMCPServer(t *testing.T) {
 	fake := faker.New()
 	makeMockDeps := func() MCPServerDeps {
 		return MCPServerDeps{
-			RootLogger:    diag.RootTestLogger(),
+			RootLogger:    telemetry.RootTestLogger(),
 			ShutdownHooks: shutdown.NewTestHooks(),
 			Controllers:   []ToolsFactory{},
 			IDGen:         ident.NewDefaultGenerator(),
@@ -101,7 +101,7 @@ func TestMCPServer(t *testing.T) {
 			deps.Controllers = newToolsFactories(
 				wantCall.Params.Name,
 				func(ctx context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-					diagCtx := diag.GetLogAttributesFromContext(ctx)
+					diagCtx := telemetry.GetLogAttributesFromContext(ctx)
 					assert.NotEmpty(t, diagCtx.CorrelationID)
 					contextChecked = true
 					return newToolCallResult(), nil
@@ -125,7 +125,7 @@ func TestMCPServer(t *testing.T) {
 			wantCorrelationID := fake.UUID().V4()
 			wantCall := makeToolCallRequest()
 
-			callCtx := diag.SetLogAttributesToContext(t.Context(), diag.LogAttributes{
+			callCtx := telemetry.SetLogAttributesToContext(t.Context(), telemetry.LogAttributes{
 				CorrelationID: slog.StringValue(wantCorrelationID),
 			})
 
@@ -133,7 +133,7 @@ func TestMCPServer(t *testing.T) {
 			deps.Controllers = newToolsFactories(
 				wantCall.Params.Name,
 				func(ctx context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-					diagCtx := diag.GetLogAttributesFromContext(ctx)
+					diagCtx := telemetry.GetLogAttributesFromContext(ctx)
 					assert.Equal(t, wantCorrelationID, diagCtx.CorrelationID.String())
 					contextChecked = true
 					return newToolCallResult(), nil

--- a/internal/app/echo_test.go
+++ b/internal/app/echo_test.go
@@ -3,7 +3,7 @@ package app
 import (
 	"testing"
 
-	"github.com/gemyago/golang-backend-boilerplate/internal/diag"
+	"github.com/gemyago/golang-backend-boilerplate/internal/telemetry"
 	"github.com/jaswdr/faker/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -13,7 +13,7 @@ func TestEchoService(t *testing.T) {
 	fake := faker.New()
 	t.Run("should echo data", func(t *testing.T) {
 		want := fake.Lorem().Sentence(10)
-		service := NewEchoService(EchoServiceDeps{RootLogger: diag.RootTestLogger()})
+		service := NewEchoService(EchoServiceDeps{RootLogger: telemetry.RootTestLogger()})
 		got, err := service.SendEcho(t.Context(), &EchoData{Message: want})
 		require.NoError(t, err)
 		assert.Equal(t, want, got.Message)

--- a/internal/app/math_test.go
+++ b/internal/app/math_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/gemyago/golang-backend-boilerplate/internal/diag"
+	"github.com/gemyago/golang-backend-boilerplate/internal/telemetry"
 	"github.com/jaswdr/faker/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -12,7 +12,7 @@ import (
 
 func makeMathServiceDeps() MathServiceDeps {
 	return MathServiceDeps{
-		RootLogger: diag.RootTestLogger(),
+		RootLogger: telemetry.RootTestLogger(),
 	}
 }
 

--- a/internal/app/pets_commands_test.go
+++ b/internal/app/pets_commands_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
-	"github.com/gemyago/golang-backend-boilerplate/internal/diag"
 	"github.com/gemyago/golang-backend-boilerplate/internal/infrastructure/petstore"
+	"github.com/gemyago/golang-backend-boilerplate/internal/telemetry"
 )
 
 func TestPetsCommands(t *testing.T) {
@@ -21,7 +21,7 @@ func TestPetsCommands(t *testing.T) {
 			PetsRepo:       NewMockPetsRepository(t),
 			UsersRepo:      NewMockUsersRepository(t),
 			PetstoreClient: NewMockPetstoreClient(t),
-			RootLogger:     diag.RootTestLogger(),
+			RootLogger:     telemetry.RootTestLogger(),
 		}
 	}
 

--- a/internal/app/pets_queries_test.go
+++ b/internal/app/pets_queries_test.go
@@ -6,8 +6,8 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/gemyago/golang-backend-boilerplate/internal/diag"
 	"github.com/gemyago/golang-backend-boilerplate/internal/infrastructure/petstore"
+	"github.com/gemyago/golang-backend-boilerplate/internal/telemetry"
 	"github.com/jaswdr/faker/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -26,7 +26,7 @@ func TestPetsQueries(t *testing.T) {
 			PetsRepo:       NewMockPetsRepository(t),
 			UsersRepo:      NewMockUsersRepository(t),
 			PetstoreClient: NewMockPetstoreClient(t),
-			RootLogger:     diag.RootTestLogger(),
+			RootLogger:     telemetry.RootTestLogger(),
 			TracerProvider: traceNoop.NewTracerProvider(),
 			MeeterProvider: meeterNoop.NewMeterProvider(),
 		}

--- a/internal/app/time_test.go
+++ b/internal/app/time_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gemyago/golang-backend-boilerplate/internal/diag"
+	"github.com/gemyago/golang-backend-boilerplate/internal/telemetry"
 	"github.com/jaswdr/faker/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -14,7 +14,7 @@ import (
 
 func makeTimeServiceDeps() TimeServiceDeps {
 	return TimeServiceDeps{
-		RootLogger: diag.RootTestLogger(),
+		RootLogger: telemetry.RootTestLogger(),
 	}
 }
 

--- a/internal/app/users_commands_test.go
+++ b/internal/app/users_commands_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/metric/noop"
 
-	"github.com/gemyago/golang-backend-boilerplate/internal/diag"
 	"github.com/gemyago/golang-backend-boilerplate/internal/system/ident"
+	"github.com/gemyago/golang-backend-boilerplate/internal/telemetry"
 )
 
 func TestUserCommands(t *testing.T) {
@@ -21,7 +21,7 @@ func TestUserCommands(t *testing.T) {
 		usersMetrics, _ := newUsersMetrics(noop.NewMeterProvider())
 		return UserCommandsDeps{
 			UsersRepo:    NewMockUsersRepository(t),
-			RootLogger:   diag.RootTestLogger(),
+			RootLogger:   telemetry.RootTestLogger(),
 			UsersMetrics: usersMetrics,
 			IDGen:        ident.NewMockGenerator(),
 		}

--- a/internal/infrastructure/database.go
+++ b/internal/infrastructure/database.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/gemyago/golang-backend-boilerplate/internal/diag"
+	"github.com/gemyago/golang-backend-boilerplate/internal/telemetry"
 	"github.com/uptrace/opentelemetry-go-extra/otelsql"
 	"go.opentelemetry.io/otel/metric"
 	semconv "go.opentelemetry.io/otel/semconv/v1.10.0"
@@ -24,7 +24,7 @@ type DatabaseDeps struct {
 	metric.MeterProvider
 	trace.TracerProvider
 
-	OTELConfig diag.OTELConfig
+	OTELConfig telemetry.OTELConfig
 
 	DSN string `name:"config.database.dsn"`
 }

--- a/internal/infrastructure/http/client_factory.go
+++ b/internal/infrastructure/http/client_factory.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/gemyago/golang-backend-boilerplate/internal/diag"
 	"github.com/gemyago/golang-backend-boilerplate/internal/infrastructure/http/middleware"
+	"github.com/gemyago/golang-backend-boilerplate/internal/telemetry"
 	"go.uber.org/dig"
 	"golang.org/x/oauth2"
 )
@@ -27,7 +27,7 @@ type ClientFactoryDeps struct {
 
 	RootLogger *slog.Logger
 
-	OtelHTTPTransportFactory diag.OtelHTTPTransportFactory
+	OtelHTTPTransportFactory telemetry.OtelHTTPTransportFactory
 }
 
 // ClientOption configures HTTP client creation.
@@ -65,7 +65,7 @@ func WithLogging(enabled bool) ClientOption {
 // ClientFactory is responsible for creating configured HTTP clients with middleware.
 type ClientFactory struct {
 	logger                   *slog.Logger
-	otelHTTPTransportFactory diag.OtelHTTPTransportFactory
+	otelHTTPTransportFactory telemetry.OtelHTTPTransportFactory
 }
 
 // NewClientFactory creates a new client factory.

--- a/internal/infrastructure/http/client_factory_test.go
+++ b/internal/infrastructure/http/client_factory_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gemyago/golang-backend-boilerplate/internal/diag"
+	"github.com/gemyago/golang-backend-boilerplate/internal/telemetry"
 	"github.com/jaswdr/faker/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -18,7 +18,7 @@ func TestClientFactory(t *testing.T) {
 	fake := faker.New()
 	makeMockDeps := func() ClientFactoryDeps {
 		return ClientFactoryDeps{
-			RootLogger: diag.RootTestLogger(),
+			RootLogger: telemetry.RootTestLogger(),
 			OtelHTTPTransportFactory: func(base http.RoundTripper) http.RoundTripper {
 				return base // No-op for testing
 			},

--- a/internal/infrastructure/http/middleware/correlation.go
+++ b/internal/infrastructure/http/middleware/correlation.go
@@ -4,7 +4,7 @@ import (
 	"log/slog"
 	"net/http"
 
-	"github.com/gemyago/golang-backend-boilerplate/internal/diag"
+	"github.com/gemyago/golang-backend-boilerplate/internal/telemetry"
 )
 
 // CorrelationMiddlewareDeps contains dependencies for the correlation middleware.
@@ -25,10 +25,10 @@ func NewCorrelationMiddleware(transport http.RoundTripper) http.RoundTripper {
 // RoundTrip implements http.RoundTripper interface.
 // Adds correlation ID header to the request.
 func (c *CorrelationMiddleware) RoundTrip(req *http.Request) (*http.Response, error) {
-	logAttrs := diag.GetLogAttributesFromContext(req.Context())
+	logAttrs := telemetry.GetLogAttributesFromContext(req.Context())
 	if logAttrs.CorrelationID.Kind() == slog.KindString {
 		if correlationID := logAttrs.CorrelationID.String(); correlationID != "" {
-			req.Header.Set(diag.CorrelationIDHeader, correlationID)
+			req.Header.Set(telemetry.CorrelationIDHeader, correlationID)
 		}
 	}
 	return c.transport.RoundTrip(req)

--- a/internal/infrastructure/http/middleware/correlation_test.go
+++ b/internal/infrastructure/http/middleware/correlation_test.go
@@ -7,7 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/gemyago/golang-backend-boilerplate/internal/diag"
+	"github.com/gemyago/golang-backend-boilerplate/internal/telemetry"
 	"github.com/jaswdr/faker/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -20,9 +20,9 @@ func TestCorrelationMiddleware_RoundTrip(t *testing.T) {
 		// Given
 		expectedCorrelationID := faker.UUID().V4()
 		ctx := context.Background()
-		logAttrs := diag.GetLogAttributesFromContext(ctx)
+		logAttrs := telemetry.GetLogAttributesFromContext(ctx)
 		logAttrs.CorrelationID = slog.StringValue(expectedCorrelationID)
-		ctx = diag.SetLogAttributesToContext(ctx, logAttrs)
+		ctx = telemetry.SetLogAttributesToContext(ctx, logAttrs)
 
 		req := httptest.NewRequest(http.MethodGet, "http://example.com", nil).WithContext(ctx)
 
@@ -34,7 +34,7 @@ func TestCorrelationMiddleware_RoundTrip(t *testing.T) {
 
 		// Then
 		require.NoError(t, err)
-		assert.Equal(t, expectedCorrelationID, req.Header.Get(diag.CorrelationIDHeader))
+		assert.Equal(t, expectedCorrelationID, req.Header.Get(telemetry.CorrelationIDHeader))
 	})
 
 	t.Run("should overwrite existing correlation ID header", func(t *testing.T) {
@@ -42,12 +42,12 @@ func TestCorrelationMiddleware_RoundTrip(t *testing.T) {
 		expectedCorrelationID := faker.UUID().V4()
 		existingHeaderValue := faker.UUID().V4()
 		ctx := context.Background()
-		logAttrs := diag.GetLogAttributesFromContext(ctx)
+		logAttrs := telemetry.GetLogAttributesFromContext(ctx)
 		logAttrs.CorrelationID = slog.StringValue(expectedCorrelationID)
-		ctx = diag.SetLogAttributesToContext(ctx, logAttrs)
+		ctx = telemetry.SetLogAttributesToContext(ctx, logAttrs)
 
 		req := httptest.NewRequest(http.MethodGet, "http://example.com", nil).WithContext(ctx)
-		req.Header.Set(diag.CorrelationIDHeader, existingHeaderValue)
+		req.Header.Set(telemetry.CorrelationIDHeader, existingHeaderValue)
 
 		mockTransport := &mockRoundTripper{}
 		middleware := NewCorrelationMiddleware(mockTransport)
@@ -57,7 +57,7 @@ func TestCorrelationMiddleware_RoundTrip(t *testing.T) {
 
 		// Then
 		require.NoError(t, err)
-		assert.Equal(t, expectedCorrelationID, req.Header.Get(diag.CorrelationIDHeader))
+		assert.Equal(t, expectedCorrelationID, req.Header.Get(telemetry.CorrelationIDHeader))
 	})
 
 	t.Run("should not set header when no correlation ID in context", func(t *testing.T) {
@@ -73,7 +73,7 @@ func TestCorrelationMiddleware_RoundTrip(t *testing.T) {
 
 		// Then
 		require.NoError(t, err)
-		assert.Empty(t, req.Header.Get(diag.CorrelationIDHeader))
+		assert.Empty(t, req.Header.Get(telemetry.CorrelationIDHeader))
 	})
 }
 

--- a/internal/infrastructure/http/middleware/logging_test.go
+++ b/internal/infrastructure/http/middleware/logging_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/gemyago/golang-backend-boilerplate/internal/diag"
+	"github.com/gemyago/golang-backend-boilerplate/internal/telemetry"
 	"github.com/jaswdr/faker/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -47,8 +47,8 @@ func TestLoggingMiddleware(t *testing.T) {
 	}
 	makeMockDeps := func() mockDeps {
 		var buf bytes.Buffer
-		logger := diag.NewRootLogger(
-			diag.NewRootLoggerOpts().
+		logger := telemetry.NewRootLogger(
+			telemetry.NewRootLoggerOpts().
 				WithJSONLogs(true).
 				WithOutput(&buf).
 				WithLogLevel(slog.LevelDebug),

--- a/internal/infrastructure/http/send_request_test.go
+++ b/internal/infrastructure/http/send_request_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/gemyago/golang-backend-boilerplate/internal/diag"
+	"github.com/gemyago/golang-backend-boilerplate/internal/telemetry"
 	"github.com/jaswdr/faker/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -141,7 +141,7 @@ func TestSendRequest(t *testing.T) {
 
 		client := server.Client()
 		client.Transport = NewClientFactory(ClientFactoryDeps{
-			RootLogger: diag.RootTestLogger(),
+			RootLogger: telemetry.RootTestLogger(),
 		}).CreateClient().Transport
 		ctx := t.Context()
 

--- a/internal/infrastructure/petstore/add_pet_test.go
+++ b/internal/infrastructure/petstore/add_pet_test.go
@@ -6,8 +6,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/gemyago/golang-backend-boilerplate/internal/diag"
 	httpservices "github.com/gemyago/golang-backend-boilerplate/internal/infrastructure/http"
+	"github.com/gemyago/golang-backend-boilerplate/internal/telemetry"
 	"github.com/jaswdr/faker/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -16,7 +16,7 @@ import (
 func TestClient_AddPet(t *testing.T) {
 	makeMockDeps := func(t *testing.T, baseURL string) ClientDeps {
 		// Always include test name in the logger for better debugging
-		rootLogger := diag.RootTestLogger().With("test", t.Name())
+		rootLogger := telemetry.RootTestLogger().With("test", t.Name())
 		return ClientDeps{
 			ClientFactory: httpservices.NewClientFactory(httpservices.ClientFactoryDeps{
 				RootLogger: rootLogger,

--- a/internal/infrastructure/petstore/get_pet_by_id_test.go
+++ b/internal/infrastructure/petstore/get_pet_by_id_test.go
@@ -7,8 +7,8 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/gemyago/golang-backend-boilerplate/internal/diag"
 	httpservices "github.com/gemyago/golang-backend-boilerplate/internal/infrastructure/http"
+	"github.com/gemyago/golang-backend-boilerplate/internal/telemetry"
 	"github.com/jaswdr/faker/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -17,7 +17,7 @@ import (
 func TestClient_GetPetByID(t *testing.T) {
 	makeMockDeps := func(t *testing.T, baseURL string) ClientDeps {
 		// Always include test name in the logger for better debugging
-		rootLogger := diag.RootTestLogger().With("test", t.Name())
+		rootLogger := telemetry.RootTestLogger().With("test", t.Name())
 		return ClientDeps{
 			ClientFactory: httpservices.NewClientFactory(httpservices.ClientFactoryDeps{
 				RootLogger: rootLogger,

--- a/internal/infrastructure/petstore/update_pet_test.go
+++ b/internal/infrastructure/petstore/update_pet_test.go
@@ -6,8 +6,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/gemyago/golang-backend-boilerplate/internal/diag"
 	httpservices "github.com/gemyago/golang-backend-boilerplate/internal/infrastructure/http"
+	"github.com/gemyago/golang-backend-boilerplate/internal/telemetry"
 	"github.com/jaswdr/faker/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -16,7 +16,7 @@ import (
 func TestClient_UpdatePet(t *testing.T) {
 	makeMockDeps := func(t *testing.T, baseURL string) ClientDeps {
 		// Always include test name in the logger for better debugging
-		rootLogger := diag.RootTestLogger().With("test", t.Name())
+		rootLogger := telemetry.RootTestLogger().With("test", t.Name())
 		return ClientDeps{
 			ClientFactory: httpservices.NewClientFactory(httpservices.ClientFactoryDeps{
 				RootLogger: rootLogger,

--- a/internal/system/shutdown/hooks_test.go
+++ b/internal/system/shutdown/hooks_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gemyago/golang-backend-boilerplate/internal/diag"
+	"github.com/gemyago/golang-backend-boilerplate/internal/telemetry"
 	"github.com/jaswdr/faker/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -34,7 +34,7 @@ func TestShutdownHooks(t *testing.T) {
 	fake := faker.New()
 	makeMockDeps := func() HooksDeps {
 		return HooksDeps{
-			RootLogger:              diag.RootTestLogger(),
+			RootLogger:              telemetry.RootTestLogger(),
 			GracefulShutdownTimeout: time.Duration(10+rand.IntN(1000)) * time.Second,
 		}
 	}

--- a/internal/system/shutdown/testing.go
+++ b/internal/system/shutdown/testing.go
@@ -5,7 +5,7 @@ package shutdown
 import (
 	"time"
 
-	"github.com/gemyago/golang-backend-boilerplate/internal/diag"
+	"github.com/gemyago/golang-backend-boilerplate/internal/telemetry"
 )
 
 const defaultTestShutdownTimeout = 30 * time.Second
@@ -13,7 +13,7 @@ const defaultTestShutdownTimeout = 30 * time.Second
 // NewTestHooks constructor for shutdown Hooks that can be used in tests.
 func NewTestHooks() *Hooks {
 	return NewHooks(HooksDeps{
-		RootLogger:              diag.RootTestLogger(),
+		RootLogger:              telemetry.RootTestLogger(),
 		GracefulShutdownTimeout: defaultTestShutdownTimeout,
 	})
 }

--- a/internal/telemetry/constants.go
+++ b/internal/telemetry/constants.go
@@ -1,3 +1,3 @@
-package diag
+package telemetry
 
 const CorrelationIDHeader = "X-Correlation-ID"

--- a/internal/telemetry/mock_slog_handler_test.go
+++ b/internal/telemetry/mock_slog_handler_test.go
@@ -4,7 +4,7 @@
 
 //go:build !release
 
-package diag
+package telemetry
 
 import (
 	"context"

--- a/internal/telemetry/otel.go
+++ b/internal/telemetry/otel.go
@@ -1,4 +1,4 @@
-package diag
+package telemetry
 
 import (
 	"log/slog"

--- a/internal/telemetry/otel_http_middleware.go
+++ b/internal/telemetry/otel_http_middleware.go
@@ -1,4 +1,4 @@
-package diag
+package telemetry
 
 import (
 	"net/http"

--- a/internal/telemetry/otel_http_middleware_test.go
+++ b/internal/telemetry/otel_http_middleware_test.go
@@ -1,4 +1,4 @@
-package diag
+package telemetry
 
 import (
 	"net/http"

--- a/internal/telemetry/otel_http_transport.go
+++ b/internal/telemetry/otel_http_transport.go
@@ -1,4 +1,4 @@
-package diag
+package telemetry
 
 import (
 	"net/http"

--- a/internal/telemetry/otel_logger.go
+++ b/internal/telemetry/otel_logger.go
@@ -1,4 +1,4 @@
-package diag
+package telemetry
 
 import (
 	"context"

--- a/internal/telemetry/otel_meter.go
+++ b/internal/telemetry/otel_meter.go
@@ -1,4 +1,4 @@
-package diag
+package telemetry
 
 import (
 	"context"

--- a/internal/telemetry/otel_resource.go
+++ b/internal/telemetry/otel_resource.go
@@ -1,4 +1,4 @@
-package diag
+package telemetry
 
 import (
 	"context"

--- a/internal/telemetry/otel_test.go
+++ b/internal/telemetry/otel_test.go
@@ -1,4 +1,4 @@
-package diag
+package telemetry
 
 import (
 	"testing"

--- a/internal/telemetry/otel_tracer.go
+++ b/internal/telemetry/otel_tracer.go
@@ -1,4 +1,4 @@
-package diag
+package telemetry
 
 import (
 	"context"

--- a/internal/telemetry/pprof.go
+++ b/internal/telemetry/pprof.go
@@ -1,4 +1,4 @@
-package diag
+package telemetry
 
 import (
 	"fmt"

--- a/internal/telemetry/register.go
+++ b/internal/telemetry/register.go
@@ -1,4 +1,4 @@
-package diag
+package telemetry
 
 import (
 	"context"

--- a/internal/telemetry/shutdown.go
+++ b/internal/telemetry/shutdown.go
@@ -1,4 +1,4 @@
-package diag
+package telemetry
 
 import (
 	"context"

--- a/internal/telemetry/slog.go
+++ b/internal/telemetry/slog.go
@@ -1,4 +1,4 @@
-package diag
+package telemetry
 
 import (
 	"context"
@@ -15,7 +15,7 @@ import (
 type contextKey string
 
 const (
-	contextDiagAttrs = contextKey("diag.context-key.log-attribs")
+	contextDiagAttrs = contextKey("telemetry.context-key.log-attribs")
 )
 
 type LogAttributes struct {

--- a/internal/telemetry/slog_attributes.go
+++ b/internal/telemetry/slog_attributes.go
@@ -1,4 +1,4 @@
-package diag
+package telemetry
 
 import "log/slog"
 

--- a/internal/telemetry/slog_test.go
+++ b/internal/telemetry/slog_test.go
@@ -1,4 +1,4 @@
-package diag
+package telemetry
 
 import (
 	"bytes"
@@ -63,7 +63,7 @@ func TestDiagSlogHandler(t *testing.T) {
 			target.EXPECT().Handle(ctx, originalRec).Return(nil)
 			assert.NoError(t, handler.Handle(ctx, originalRec))
 		})
-		t.Run("should add diag attributes", func(t *testing.T) {
+		t.Run("should add telemetry attributes", func(t *testing.T) {
 			target := NewMockSlogHandler(t)
 
 			handler := diagLogHandler{target: target}

--- a/internal/telemetry/testing.go
+++ b/internal/telemetry/testing.go
@@ -1,9 +1,9 @@
 //go:build !release
 
 // TODO: generated code should include "//go:build !release" tags
-//go:generate mockgen -typed -package diag -destination mock_slog_handler_test.go log/slog Handler
+//go:generate mockgen -typed -package telemetry -destination mock_slog_handler_test.go log/slog Handler
 
-package diag
+package telemetry
 
 import (
 	"fmt"

--- a/internal/wireup.go
+++ b/internal/wireup.go
@@ -8,11 +8,11 @@ import (
 	"github.com/gemyago/golang-backend-boilerplate/internal/app"
 	"github.com/gemyago/golang-backend-boilerplate/internal/config"
 	"github.com/gemyago/golang-backend-boilerplate/internal/di"
-	"github.com/gemyago/golang-backend-boilerplate/internal/diag"
 	"github.com/gemyago/golang-backend-boilerplate/internal/infrastructure"
 	"github.com/gemyago/golang-backend-boilerplate/internal/system/apptime"
 	"github.com/gemyago/golang-backend-boilerplate/internal/system/ident"
 	"github.com/gemyago/golang-backend-boilerplate/internal/system/shutdown"
+	"github.com/gemyago/golang-backend-boilerplate/internal/telemetry"
 	"github.com/spf13/viper"
 	otellog "go.opentelemetry.io/otel/log"
 	"go.uber.org/dig"
@@ -34,11 +34,11 @@ func Setup(
 	}
 
 	newRootLoggerOptions := func(
-		otelConfig diag.OTELConfig,
-		otelLogsConfig diag.OTELLogsConfig,
+		otelConfig telemetry.OTELConfig,
+		otelLogsConfig telemetry.OTELLogsConfig,
 		otellogProvider otellog.LoggerProvider,
-	) *diag.RootLoggerOpts {
-		return diag.NewRootLoggerOpts().
+	) *telemetry.RootLoggerOpts {
+		return telemetry.NewRootLoggerOpts().
 			WithJSONLogs(cfg.GetBool("jsonLogs")).
 			WithLogLevel(logLevel).
 			WithOptionalOutputFile(cfg.GetString("logs-file")).
@@ -56,16 +56,16 @@ func Setup(
 			ident.NewDefaultGenerator,
 			di.ProvideImplementation[*ident.DefaultGenerator, ident.Generator],
 
-			// We can't directly use shutdown hooks in diag, since diag is used everywhere.
+			// We can't directly use shutdown hooks in telemetry, since telemetry is used everywhere.
 			// This is a good place to register the implementation.
 			shutdown.NewHooks,
-			di.ProvideImplementation[*shutdown.Hooks, diag.ShutdownHooks],
+			di.ProvideImplementation[*shutdown.Hooks, telemetry.ShutdownHooks],
 		),
 
 		config.Provide(container, cfg),
 
-		// diag needs to happen separately
-		diag.Register(rootCtx, container),
+		// telemetry needs to happen separately
+		telemetry.Register(rootCtx, container),
 
 		// app layer
 		app.Register(container),
@@ -74,6 +74,6 @@ func Setup(
 		infrastructure.Register(rootCtx, container),
 
 		// some setup after all components are registered
-		container.Invoke(diag.OTELSetup),
+		container.Invoke(telemetry.OTELSetup),
 	)
 }


### PR DESCRIPTION
* Renamed internal/diag package to internal/telemetry for better alignment with industry standards and project structure.
* Updated all imports and references across the codebase to use the new internal/telemetry package.
* Updated .mockery.yaml and documentation to reflect the package name change.
* Ensured all tests and linters pass.

closes #54 