### PR TITLE
Refactor lifecycle management with shutdown hooks and startup coordination

### DIFF
--- a/cmd/mcp/http.go
+++ b/cmd/mcp/http.go
@@ -2,23 +2,18 @@ package main
 
 import (
 	"context"
-	"errors"
 	"log/slog"
-	"os/signal"
-	"time"
 
 	mcpserver "github.com/gemyago/golang-backend-boilerplate/internal/api/mcp/server"
 	"github.com/gemyago/golang-backend-boilerplate/internal/system/lifecycle"
-	"github.com/gemyago/golang-backend-boilerplate/internal/telemetry"
 	"github.com/spf13/cobra"
 	"go.uber.org/dig"
-	"golang.org/x/sys/unix"
 )
 
 type startHTTPServerParams struct {
 	dig.In `ignore-unexported:"true"`
 
-	ShutdownHooks *lifecycle.ShutdownHooks
+	StartupGroupFactory lifecycle.StartupGroupFactory
 
 	RootLogger *slog.Logger
 
@@ -31,46 +26,16 @@ func startHTTPServer(rootCtx context.Context, params startHTTPServerParams) erro
 	rootLogger := params.RootLogger
 	httpServer := params.MCPServer.NewStreamableHTTPServer()
 
-	shutdown := func() error {
-		rootLogger.InfoContext(rootCtx, "Trying to shut down gracefully")
-		ts := time.Now()
-
-		err := params.ShutdownHooks.PerformShutdown(rootCtx)
-		if err != nil {
-			rootLogger.ErrorContext(rootCtx, "Failed to shut down gracefully", telemetry.ErrAttr(err))
-		}
-
-		rootLogger.InfoContext(rootCtx, "Service stopped",
-			slog.Duration("duration", time.Since(ts)),
-		)
-		return err
-	}
-
-	signalCtx, cancel := signal.NotifyContext(rootCtx, unix.SIGINT, unix.SIGTERM)
-	defer cancel()
-
-	const startedComponents = 2
-	startupErrors := make(chan error, startedComponents)
-	go func() {
+	startupGroup := params.StartupGroupFactory.NewGroup()
+	startupGroup.Add(func(ctx context.Context) error {
 		if params.noop {
-			rootLogger.InfoContext(signalCtx, "NOOP: Starting http server")
-			startupErrors <- nil
-			return
+			rootLogger.InfoContext(ctx, "NOOP: Starting http server")
+			return nil
 		}
-		startupErrors <- httpServer.Start(signalCtx)
-	}()
+		return httpServer.Start(ctx)
+	})
 
-	var startupErr error
-	select {
-	case startupErr = <-startupErrors:
-		if startupErr != nil {
-			rootLogger.ErrorContext(rootCtx, "Server startup failed", "err", startupErr)
-		}
-	case <-signalCtx.Done(): // coverage-ignore
-		// We will attempt to shut down in both cases
-		// so doing it once on a next line
-	}
-	return errors.Join(startupErr, shutdown())
+	return startupGroup.Start(rootCtx)
 }
 
 func newHTTPCmd(container *dig.Container) *cobra.Command {

--- a/cmd/mcp/http.go
+++ b/cmd/mcp/http.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	mcpserver "github.com/gemyago/golang-backend-boilerplate/internal/api/mcp/server"
-	"github.com/gemyago/golang-backend-boilerplate/internal/system/shutdown"
+	"github.com/gemyago/golang-backend-boilerplate/internal/system/lifecycle"
 	"github.com/gemyago/golang-backend-boilerplate/internal/telemetry"
 	"github.com/spf13/cobra"
 	"go.uber.org/dig"
@@ -18,7 +18,7 @@ import (
 type startHTTPServerParams struct {
 	dig.In `ignore-unexported:"true"`
 
-	ShutdownHooks *shutdown.Hooks
+	ShutdownHooks *lifecycle.ShutdownHooks
 
 	RootLogger *slog.Logger
 

--- a/cmd/mcp/stdio.go
+++ b/cmd/mcp/stdio.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	mcpserver "github.com/gemyago/golang-backend-boilerplate/internal/api/mcp/server"
-	"github.com/gemyago/golang-backend-boilerplate/internal/system/shutdown"
+	"github.com/gemyago/golang-backend-boilerplate/internal/system/lifecycle"
 	"github.com/gemyago/golang-backend-boilerplate/internal/telemetry"
 	"github.com/spf13/cobra"
 	"go.uber.org/dig"
@@ -19,7 +19,7 @@ import (
 type stdioServerParams struct {
 	dig.In `ignore-unexported:"true"`
 
-	ShutdownHooks *shutdown.Hooks
+	ShutdownHooks *lifecycle.ShutdownHooks
 
 	RootLogger *slog.Logger
 

--- a/cmd/mcp/stdio.go
+++ b/cmd/mcp/stdio.go
@@ -2,24 +2,19 @@ package main
 
 import (
 	"context"
-	"errors"
 	"log/slog"
 	"os"
-	"os/signal"
-	"time"
 
 	mcpserver "github.com/gemyago/golang-backend-boilerplate/internal/api/mcp/server"
 	"github.com/gemyago/golang-backend-boilerplate/internal/system/lifecycle"
-	"github.com/gemyago/golang-backend-boilerplate/internal/telemetry"
 	"github.com/spf13/cobra"
 	"go.uber.org/dig"
-	"golang.org/x/sys/unix"
 )
 
 type stdioServerParams struct {
 	dig.In `ignore-unexported:"true"`
 
-	ShutdownHooks *lifecycle.ShutdownHooks
+	StartupGroupFactory lifecycle.StartupGroupFactory
 
 	RootLogger *slog.Logger
 
@@ -31,46 +26,15 @@ type stdioServerParams struct {
 func startStdioServer(rootCtx context.Context, params stdioServerParams) error {
 	rootLogger := params.RootLogger
 
-	shutdown := func() error {
-		rootLogger.InfoContext(rootCtx, "Trying to shut down gracefully")
-		ts := time.Now()
-
-		err := params.ShutdownHooks.PerformShutdown(rootCtx)
-		if err != nil {
-			rootLogger.ErrorContext(rootCtx, "Failed to shut down gracefully", telemetry.ErrAttr(err))
-		}
-
-		rootLogger.InfoContext(rootCtx, "Service stopped",
-			slog.Duration("duration", time.Since(ts)),
-		)
-		return err
-	}
-
-	signalCtx, cancel := signal.NotifyContext(rootCtx, unix.SIGINT, unix.SIGTERM)
-	defer cancel()
-
-	const startedComponents = 2
-	startupErrors := make(chan error, startedComponents)
-	go func() {
+	startupGroup := params.StartupGroupFactory.NewGroup()
+	startupGroup.Add(func(ctx context.Context) error {
 		if params.noop {
-			rootLogger.InfoContext(signalCtx, "NOOP: Starting stdio server")
-			startupErrors <- nil
-			return
+			rootLogger.InfoContext(ctx, "NOOP: Starting stdio server")
+			return nil
 		}
-		startupErrors <- params.MCPServer.ListenStdioServer(signalCtx, os.Stdin, os.Stdout)
-	}()
-
-	var startupErr error
-	select {
-	case startupErr = <-startupErrors:
-		if startupErr != nil {
-			rootLogger.ErrorContext(rootCtx, "Server startup failed", "err", startupErr)
-		}
-	case <-signalCtx.Done(): // coverage-ignore
-		// We will attempt to shut down in both cases
-		// so doing it once on a next line
-	}
-	return errors.Join(startupErr, shutdown())
+		return params.MCPServer.ListenStdioServer(ctx, os.Stdin, os.Stdout)
+	})
+	return startupGroup.Start(rootCtx)
 }
 
 func newStdioCmd(container *dig.Container) *cobra.Command {

--- a/cmd/server/start.go
+++ b/cmd/server/start.go
@@ -4,24 +4,19 @@ import (
 	"context"
 	"errors"
 	"log/slog"
-	"os/signal"
-	"time"
 
 	"github.com/gemyago/golang-backend-boilerplate/internal/api/http"
 	"github.com/gemyago/golang-backend-boilerplate/internal/api/http/server"
 	"github.com/gemyago/golang-backend-boilerplate/internal/system/lifecycle"
-	"github.com/gemyago/golang-backend-boilerplate/internal/telemetry"
 	"github.com/spf13/cobra"
 	"go.uber.org/dig"
-	"golang.org/x/sys/unix"
 )
 
 type startServerParams struct {
 	dig.In `ignore-unexported:"true"`
 
-	ShutdownHooks *lifecycle.ShutdownHooks
-
-	RootLogger *slog.Logger
+	StartupGroupFactory lifecycle.StartupGroupFactory
+	RootLogger          *slog.Logger
 
 	HTTPServer *server.HTTPServer
 
@@ -33,46 +28,16 @@ func startServer(params startServerParams) error {
 	httpServer := params.HTTPServer
 	rootCtx := context.Background()
 
-	shutdown := func() error {
-		rootLogger.InfoContext(rootCtx, "Trying to shut down gracefully")
-		ts := time.Now()
-
-		err := params.ShutdownHooks.PerformShutdown(rootCtx)
-		if err != nil {
-			rootLogger.ErrorContext(rootCtx, "Failed to shut down gracefully", telemetry.ErrAttr(err))
-		}
-
-		rootLogger.InfoContext(rootCtx, "Service stopped",
-			slog.Duration("duration", time.Since(ts)),
-		)
-		return err
-	}
-
-	signalCtx, cancel := signal.NotifyContext(rootCtx, unix.SIGINT, unix.SIGTERM)
-	defer cancel()
-
-	const startedComponents = 2
-	startupErrors := make(chan error, startedComponents)
-	go func() {
+	startupGroup := params.StartupGroupFactory.NewGroup()
+	startupGroup.Add(func(ctx context.Context) error {
 		if params.noop {
-			rootLogger.InfoContext(signalCtx, "NOOP: Starting http server")
-			startupErrors <- nil
-			return
+			rootLogger.InfoContext(ctx, "NOOP: Starting http server")
+			return nil
 		}
-		startupErrors <- httpServer.Start(signalCtx)
-	}()
+		return httpServer.Start(ctx)
+	})
 
-	var startupErr error
-	select {
-	case startupErr = <-startupErrors:
-		if startupErr != nil {
-			rootLogger.ErrorContext(rootCtx, "Server startup failed", "err", startupErr)
-		}
-	case <-signalCtx.Done(): // coverage-ignore
-		// We will attempt to shut down in both cases
-		// so doing it once on a next line
-	}
-	return errors.Join(startupErr, shutdown())
+	return startupGroup.Start(rootCtx)
 }
 
 func newStartServerCmd(container *dig.Container) *cobra.Command {

--- a/cmd/server/start.go
+++ b/cmd/server/start.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/gemyago/golang-backend-boilerplate/internal/api/http"
 	"github.com/gemyago/golang-backend-boilerplate/internal/api/http/server"
-	"github.com/gemyago/golang-backend-boilerplate/internal/system/shutdown"
+	"github.com/gemyago/golang-backend-boilerplate/internal/system/lifecycle"
 	"github.com/gemyago/golang-backend-boilerplate/internal/telemetry"
 	"github.com/spf13/cobra"
 	"go.uber.org/dig"
@@ -19,7 +19,7 @@ import (
 type startServerParams struct {
 	dig.In `ignore-unexported:"true"`
 
-	ShutdownHooks *shutdown.Hooks
+	ShutdownHooks *lifecycle.ShutdownHooks
 
 	RootLogger *slog.Logger
 

--- a/internal/api/http/server/server.go
+++ b/internal/api/http/server/server.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/gemyago/golang-backend-boilerplate/internal/system/ident"
-	"github.com/gemyago/golang-backend-boilerplate/internal/system/shutdown"
+	"github.com/gemyago/golang-backend-boilerplate/internal/system/lifecycle"
 	"github.com/gemyago/golang-backend-boilerplate/internal/telemetry"
 	sloghttp "github.com/samber/slog-http"
 	"go.uber.org/dig"
@@ -22,7 +22,7 @@ type HTTPServerDeps struct {
 	dig.In `ignore-unexported:"true"`
 
 	// services
-	ShutdownHooks *shutdown.Hooks
+	ShutdownHooks *lifecycle.ShutdownHooks
 
 	RootLogger *slog.Logger
 

--- a/internal/api/http/server/server_test.go
+++ b/internal/api/http/server/server_test.go
@@ -14,7 +14,7 @@ import (
 	"time"
 
 	"github.com/gemyago/golang-backend-boilerplate/internal/system/ident"
-	"github.com/gemyago/golang-backend-boilerplate/internal/system/shutdown"
+	"github.com/gemyago/golang-backend-boilerplate/internal/system/lifecycle"
 	"github.com/gemyago/golang-backend-boilerplate/internal/telemetry"
 	"github.com/jaswdr/faker/v2"
 	"github.com/stretchr/testify/assert"
@@ -28,7 +28,7 @@ func TestHTTPServer(t *testing.T) {
 			RootLogger:    telemetry.RootTestLogger(),
 			Host:          "localhost",
 			Port:          port,
-			ShutdownHooks: shutdown.NewTestHooks(),
+			ShutdownHooks: lifecycle.NewTestShutdownHooks(),
 			Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusOK)
 			}),

--- a/internal/api/mcp/server/server.go
+++ b/internal/api/mcp/server/server.go
@@ -8,7 +8,7 @@ import (
 
 	httpserver "github.com/gemyago/golang-backend-boilerplate/internal/api/http/server"
 	"github.com/gemyago/golang-backend-boilerplate/internal/system/ident"
-	"github.com/gemyago/golang-backend-boilerplate/internal/system/shutdown"
+	"github.com/gemyago/golang-backend-boilerplate/internal/system/lifecycle"
 	"github.com/gemyago/golang-backend-boilerplate/internal/telemetry"
 	"github.com/mark3labs/mcp-go/mcp"
 	mcpserver "github.com/mark3labs/mcp-go/server"
@@ -37,7 +37,7 @@ func (f ToolsFactoryFunc) NewTools() []mcpserver.ServerTool {
 type MCPServerDeps struct {
 	dig.In
 
-	ShutdownHooks *shutdown.Hooks
+	ShutdownHooks *lifecycle.ShutdownHooks
 
 	RootLogger *slog.Logger
 	IDGen      ident.Generator
@@ -63,7 +63,7 @@ type MCPServer struct {
 	mcpServer     *mcpserver.MCPServer
 	deps          MCPServerDeps
 	logger        *slog.Logger
-	shutdownHooks *shutdown.Hooks
+	shutdownHooks *lifecycle.ShutdownHooks
 }
 
 // NewMCPServer creates a new MCP server instance.

--- a/internal/api/mcp/server/server_test.go
+++ b/internal/api/mcp/server/server_test.go
@@ -9,7 +9,7 @@ import (
 	"net/http"
 
 	"github.com/gemyago/golang-backend-boilerplate/internal/system/ident"
-	"github.com/gemyago/golang-backend-boilerplate/internal/system/shutdown"
+	"github.com/gemyago/golang-backend-boilerplate/internal/system/lifecycle"
 	"github.com/gemyago/golang-backend-boilerplate/internal/telemetry"
 	"github.com/jaswdr/faker/v2"
 	"github.com/mark3labs/mcp-go/mcp"
@@ -23,7 +23,7 @@ func TestMCPServer(t *testing.T) {
 	makeMockDeps := func() MCPServerDeps {
 		return MCPServerDeps{
 			RootLogger:    telemetry.RootTestLogger(),
-			ShutdownHooks: shutdown.NewTestHooks(),
+			ShutdownHooks: lifecycle.NewTestShutdownHooks(),
 			Controllers:   []ToolsFactory{},
 			IDGen:         ident.NewDefaultGenerator(),
 		}

--- a/internal/infrastructure/database.go
+++ b/internal/infrastructure/database.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/gemyago/golang-backend-boilerplate/internal/system/lifecycle"
 	"github.com/gemyago/golang-backend-boilerplate/internal/telemetry"
 	"github.com/uptrace/opentelemetry-go-extra/otelsql"
 	"go.opentelemetry.io/otel/metric"
@@ -23,6 +24,7 @@ type DatabaseDeps struct {
 
 	metric.MeterProvider
 	trace.TracerProvider
+	*lifecycle.ShutdownHooks
 
 	OTELConfig telemetry.OTELConfig
 
@@ -78,6 +80,8 @@ func newDBProvider(ctx context.Context) func(DatabaseDeps) (*Database, error) {
 		); err != nil {
 			return nil, fmt.Errorf("failed to initialize schema: %w", err)
 		}
+
+		deps.ShutdownHooks.RegisterNoCtx("database", db.Close)
 
 		return &Database{instance: db}, nil
 	}

--- a/internal/infrastructure/database_test.go
+++ b/internal/infrastructure/database_test.go
@@ -5,6 +5,7 @@ import (
 	"path"
 	"testing"
 
+	"github.com/gemyago/golang-backend-boilerplate/internal/system/lifecycle"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -12,7 +13,8 @@ import (
 func TestSetupDatabase(t *testing.T) {
 	t.Run("should setup the database with all tables", func(t *testing.T) {
 		db, err := newDBProvider(t.Context())(DatabaseDeps{
-			DSN: ":memory:",
+			DSN:           ":memory:",
+			ShutdownHooks: lifecycle.NewTestShutdownHooks(),
 		})
 		require.NoError(t, err)
 
@@ -43,7 +45,8 @@ func TestSetupDatabase(t *testing.T) {
 		require.NoError(t, os.Chmod(dbFilePath, 0400))
 
 		_, err = newDBProvider(t.Context())(DatabaseDeps{
-			DSN: dbFilePath,
+			DSN:           dbFilePath,
+			ShutdownHooks: lifecycle.NewTestShutdownHooks(),
 		})
 		require.Error(t, err)
 		assert.Regexp(t, `failed to initialize schema`, err.Error())

--- a/internal/infrastructure/database_testing.go
+++ b/internal/infrastructure/database_testing.go
@@ -1,0 +1,46 @@
+//go:build !release
+
+package infrastructure
+
+import (
+	"testing"
+
+	"github.com/gemyago/golang-backend-boilerplate/internal/config"
+	"github.com/gemyago/golang-backend-boilerplate/internal/system/lifecycle"
+	"github.com/stretchr/testify/require"
+	metricnoop "go.opentelemetry.io/otel/metric/noop"
+	tracenoop "go.opentelemetry.io/otel/trace/noop"
+)
+
+type testDatabaseOpts func(deps *DatabaseDeps)
+
+func newTestDatabase(t *testing.T, opts ...testDatabaseOpts) *Database {
+	t.Helper()
+
+	cfg := config.New()
+
+	env := cfg.GetString("env")
+	if env == "" {
+		env = "test"
+	}
+
+	err := config.Load(cfg, config.NewLoadOpts().WithEnv(env))
+	require.NoError(t, err)
+
+	deps := DatabaseDeps{
+		ShutdownHooks:  lifecycle.NewTestShutdownHooks(),
+		MeterProvider:  metricnoop.NewMeterProvider(),
+		TracerProvider: tracenoop.NewTracerProvider(),
+		DSN:            cfg.GetString("database.dsn"),
+	}
+	for _, opt := range opts {
+		opt(&deps)
+	}
+	db, err := newDBProvider(t.Context())(deps)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		db.instance.Close()
+	})
+
+	return db
+}

--- a/internal/infrastructure/pets_repository_test.go
+++ b/internal/infrastructure/pets_repository_test.go
@@ -11,15 +11,8 @@ import (
 
 func TestPetsRepository(t *testing.T) {
 	makeMockDeps := func(t *testing.T) petsRepositoryDeps {
-		db, err := newDBProvider(t.Context())(DatabaseDeps{
-			DSN: ":memory:",
-		})
-		require.NoError(t, err)
-		t.Cleanup(func() {
-			db.instance.Close()
-		})
 		return petsRepositoryDeps{
-			DB:   db,
+			DB:   newTestDatabase(t),
 			Time: apptime.NewMockProvider(),
 		}
 	}

--- a/internal/infrastructure/users_repository_test.go
+++ b/internal/infrastructure/users_repository_test.go
@@ -15,15 +15,8 @@ import (
 
 func TestUsersRepository(t *testing.T) {
 	makeMockDeps := func(t *testing.T) usersRepositoryDeps {
-		db, err := newDBProvider(t.Context())(DatabaseDeps{
-			DSN: ":memory:",
-		})
-		require.NoError(t, err)
-		t.Cleanup(func() {
-			db.instance.Close()
-		})
 		return usersRepositoryDeps{
-			DB:    db,
+			DB:    newTestDatabase(t),
 			Time:  apptime.NewMockProvider(),
 			IDGen: ident.NewMockGenerator(),
 		}

--- a/internal/system/lifecycle/shutdown_hooks.go
+++ b/internal/system/lifecycle/shutdown_hooks.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/gemyago/golang-backend-boilerplate/internal/telemetry"
 	"go.uber.org/dig"
 )
 
@@ -66,6 +67,9 @@ func (h *ShutdownHooks) RegisterNoCtx(name string, shutdown func() error) {
 }
 
 func (h *ShutdownHooks) PerformShutdown(ctx context.Context) error {
+	ts := time.Now()
+	h.logger.InfoContext(ctx, "Attempting to shut down gracefully")
+
 	ctx, cancel := context.WithTimeout(ctx, h.deps.GracefulShutdownTimeout)
 	defer cancel()
 
@@ -103,6 +107,12 @@ func (h *ShutdownHooks) PerformShutdown(ctx context.Context) error {
 
 	select {
 	case err := <-done:
+		if err != nil {
+			h.logger.ErrorContext(ctx, "Failed to shut down gracefully", telemetry.ErrAttr(err))
+		}
+		h.logger.InfoContext(ctx, "Application stopped",
+			slog.Duration("duration", time.Since(ts)),
+		)
 		return err
 	case <-ctx.Done():
 		return fmt.Errorf("shutdown hooks did not complete timely: %w", ctx.Err())

--- a/internal/system/lifecycle/shutdown_hooks.go
+++ b/internal/system/lifecycle/shutdown_hooks.go
@@ -6,13 +6,14 @@ package lifecycle
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"reflect"
+	"sync"
 	"time"
 
 	"go.uber.org/dig"
-	"golang.org/x/sync/errgroup"
 )
 
 type shutdownHook struct {
@@ -68,27 +69,42 @@ func (h *ShutdownHooks) PerformShutdown(ctx context.Context) error {
 	ctx, cancel := context.WithTimeout(ctx, h.deps.GracefulShutdownTimeout)
 	defer cancel()
 
-	errGrp := errgroup.Group{}
+	resultsChan := make(chan error, len(h.hooks))
+
+	var wg sync.WaitGroup
+
 	for _, hook := range h.hooks {
-		errGrp.Go(func() error {
+		wg.Add(1)
+		go func() {
 			hookName := hook.name
 			h.logger.InfoContext(ctx, fmt.Sprintf("Shutting down %s", hookName))
 			if err := hook.shutdownFn(ctx); err != nil {
-				return fmt.Errorf("failed to perform shutdown hook %s: %w", hookName, err)
+				resultsChan <- fmt.Errorf("failed to perform shutdown hook %s: %w", hookName, err)
+			} else {
+				resultsChan <- nil
 			}
-			return nil
-		})
+			wg.Done()
+		}()
 	}
 
 	done := make(chan error)
 	go func() {
-		done <- errGrp.Wait()
+		wg.Wait()
+		close(resultsChan)
+		errs := make([]error, 0)
+		for err := range resultsChan {
+			if err != nil {
+				errs = append(errs, err)
+			}
+		}
+
+		done <- errors.Join(errs...)
 	}()
 
 	select {
 	case err := <-done:
 		return err
 	case <-ctx.Done():
-		return ctx.Err()
+		return fmt.Errorf("shutdown hooks did not complete timely: %w", ctx.Err())
 	}
 }

--- a/internal/system/lifecycle/shutdown_hooks.go
+++ b/internal/system/lifecycle/shutdown_hooks.go
@@ -2,7 +2,7 @@
 // of the application. This may include closing database connections,
 // shutting down the http server, etc.
 
-package shutdown
+package lifecycle
 
 import (
 	"context"
@@ -15,12 +15,12 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-type hook struct {
+type shutdownHook struct {
 	name       string
 	shutdownFn func(ctx context.Context) error
 }
 
-type HooksDeps struct {
+type ShutdownHooksDeps struct {
 	dig.In
 
 	RootLogger *slog.Logger
@@ -29,15 +29,15 @@ type HooksDeps struct {
 	GracefulShutdownTimeout time.Duration `name:"config.gracefulShutdownTimeout"`
 }
 
-type Hooks struct {
+type ShutdownHooks struct {
 	logger *slog.Logger
-	hooks  []hook
-	deps   HooksDeps
+	hooks  []shutdownHook
+	deps   ShutdownHooksDeps
 }
 
-// NewHooks creates a new instance of Hooks.
-func NewHooks(deps HooksDeps) *Hooks {
-	return &Hooks{
+// NewShutdownHooks creates a new instance of Hooks.
+func NewShutdownHooks(deps ShutdownHooksDeps) *ShutdownHooks {
+	return &ShutdownHooks{
 		logger: deps.RootLogger.WithGroup("shutdown"),
 		deps:   deps,
 	}
@@ -45,7 +45,7 @@ func NewHooks(deps HooksDeps) *Hooks {
 
 // HasHook checks if a shutdown hook with the given name is registered.
 // Typical usage is in tests and must be carefully considered for production scenarios.
-func (h *Hooks) HasHook(name string, method any) bool {
+func (h *ShutdownHooks) HasHook(name string, method any) bool {
 	for _, hook := range h.hooks {
 		if hook.name == name {
 			return reflect.ValueOf(hook.shutdownFn).Pointer() == reflect.ValueOf(method).Pointer()
@@ -54,17 +54,17 @@ func (h *Hooks) HasHook(name string, method any) bool {
 	return false
 }
 
-func (h *Hooks) Register(name string, shutdown func(ctx context.Context) error) {
-	h.hooks = append(h.hooks, hook{name: name, shutdownFn: shutdown})
+func (h *ShutdownHooks) Register(name string, shutdown func(ctx context.Context) error) {
+	h.hooks = append(h.hooks, shutdownHook{name: name, shutdownFn: shutdown})
 }
 
-func (h *Hooks) RegisterNoCtx(name string, shutdown func() error) {
+func (h *ShutdownHooks) RegisterNoCtx(name string, shutdown func() error) {
 	h.Register(name, func(_ context.Context) error {
 		return shutdown()
 	})
 }
 
-func (h *Hooks) PerformShutdown(ctx context.Context) error {
+func (h *ShutdownHooks) PerformShutdown(ctx context.Context) error {
 	ctx, cancel := context.WithTimeout(ctx, h.deps.GracefulShutdownTimeout)
 	defer cancel()
 

--- a/internal/system/lifecycle/shutdown_hooks.go
+++ b/internal/system/lifecycle/shutdown_hooks.go
@@ -68,6 +68,11 @@ func (h *ShutdownHooks) RegisterNoCtx(name string, shutdown func() error) {
 
 func (h *ShutdownHooks) PerformShutdown(ctx context.Context) error {
 	ts := time.Now()
+	defer func() {
+		h.logger.InfoContext(ctx, "Application stopped",
+			slog.Duration("duration", time.Since(ts)),
+		)
+	}()
 	h.logger.InfoContext(ctx, "Attempting to shut down gracefully")
 
 	ctx, cancel := context.WithTimeout(ctx, h.deps.GracefulShutdownTimeout)
@@ -110,11 +115,9 @@ func (h *ShutdownHooks) PerformShutdown(ctx context.Context) error {
 		if err != nil {
 			h.logger.ErrorContext(ctx, "Failed to shut down gracefully", telemetry.ErrAttr(err))
 		}
-		h.logger.InfoContext(ctx, "Application stopped",
-			slog.Duration("duration", time.Since(ts)),
-		)
 		return err
 	case <-ctx.Done():
+		h.logger.WarnContext(ctx, "Shutdown hooks did not complete timely", telemetry.ErrAttr(ctx.Err()))
 		return fmt.Errorf("shutdown hooks did not complete timely: %w", ctx.Err())
 	}
 }

--- a/internal/system/lifecycle/shutdown_hooks_test.go
+++ b/internal/system/lifecycle/shutdown_hooks_test.go
@@ -1,4 +1,4 @@
-package shutdown
+package lifecycle
 
 import (
 	"context"
@@ -32,8 +32,8 @@ func (m *mockShutdownHook) shutdownNoCtx() error {
 
 func TestShutdownHooks(t *testing.T) {
 	fake := faker.New()
-	makeMockDeps := func() HooksDeps {
-		return HooksDeps{
+	makeMockDeps := func() ShutdownHooksDeps {
+		return ShutdownHooksDeps{
 			RootLogger:              telemetry.RootTestLogger(),
 			GracefulShutdownTimeout: time.Duration(10+rand.IntN(1000)) * time.Second,
 		}
@@ -42,7 +42,7 @@ func TestShutdownHooks(t *testing.T) {
 	t.Run("HasHook", func(t *testing.T) {
 		t.Run("should return true if such hook has been registered", func(t *testing.T) {
 			deps := makeMockDeps()
-			registry := NewHooks(deps)
+			registry := NewShutdownHooks(deps)
 			hookName := fake.Lorem().Word()
 			fn := func(_ context.Context) error { return nil }
 			assert.False(t, registry.HasHook(hookName, fn))
@@ -55,7 +55,7 @@ func TestShutdownHooks(t *testing.T) {
 	t.Run("PerformShutdown", func(t *testing.T) {
 		t.Run("should call all hooks", func(t *testing.T) {
 			deps := makeMockDeps()
-			registry := NewHooks(deps)
+			registry := NewShutdownHooks(deps)
 
 			hooks := []*mockShutdownHook{
 				{name: fake.Lorem().Word()},
@@ -80,7 +80,7 @@ func TestShutdownHooks(t *testing.T) {
 
 		t.Run("should call hooks without context", func(t *testing.T) {
 			deps := makeMockDeps()
-			registry := NewHooks(deps)
+			registry := NewShutdownHooks(deps)
 
 			hooks := []*mockShutdownHook{
 				{name: fake.Lorem().Word()},
@@ -105,7 +105,7 @@ func TestShutdownHooks(t *testing.T) {
 
 		t.Run("should return error if any hook fails", func(t *testing.T) {
 			deps := makeMockDeps()
-			registry := NewHooks(deps)
+			registry := NewShutdownHooks(deps)
 
 			hooks := []*mockShutdownHook{
 				{name: fake.Lorem().Word()},

--- a/internal/system/lifecycle/shutdown_hooks_test.go
+++ b/internal/system/lifecycle/shutdown_hooks_test.go
@@ -132,5 +132,41 @@ func TestShutdownHooks(t *testing.T) {
 				hook.AssertExpectations(t)
 			}
 		})
+
+		t.Run("should call all hooks even if some fail and return joined errors", func(t *testing.T) {
+			deps := makeMockDeps()
+			registry := NewShutdownHooks(deps)
+
+			ctx := t.Context()
+
+			// Given three hooks where two will fail
+			err1 := errors.New(fake.Lorem().Sentence(10))
+			err2 := errors.New(fake.Lorem().Sentence(10))
+
+			hook1 := &mockShutdownHook{name: "hook1-fail"}
+			hook1.On("shutdown", mock.AnythingOfType("*context.timerCtx")).Return(err1)
+			registry.Register(hook1.name, hook1.shutdown)
+
+			hook2 := &mockShutdownHook{name: "hook2-success"}
+			hook2.On("shutdown", mock.AnythingOfType("*context.timerCtx")).Return(nil)
+			registry.Register(hook2.name, hook2.shutdown)
+
+			hook3 := &mockShutdownHook{name: "hook3-fail"}
+			hook3.On("shutdown", mock.AnythingOfType("*context.timerCtx")).Return(err2)
+			registry.Register(hook3.name, hook3.shutdown)
+
+			// When performing shutdown
+			err := registry.PerformShutdown(ctx)
+
+			// Then all hooks should be called
+			hook1.AssertExpectations(t)
+			hook2.AssertExpectations(t)
+			hook3.AssertExpectations(t)
+
+			// And error should contain both failures
+			require.Error(t, err)
+			require.ErrorIs(t, err, err1)
+			require.ErrorIs(t, err, err2)
+		})
 	})
 }

--- a/internal/system/lifecycle/startup_group.go
+++ b/internal/system/lifecycle/startup_group.go
@@ -1,0 +1,96 @@
+package lifecycle
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+	"os/signal"
+	"time"
+
+	"github.com/gemyago/golang-backend-boilerplate/internal/telemetry"
+	"go.uber.org/dig"
+	"golang.org/x/sys/unix"
+)
+
+type StartupGroupFactory struct {
+	dig.In
+
+	ShutdownHooks *ShutdownHooks
+	RootLogger    *slog.Logger
+}
+
+func (f *StartupGroupFactory) NewGroup() *StartupGroup {
+	return &StartupGroup{
+		shutdownHooks: f.ShutdownHooks,
+		logger:        f.RootLogger.WithGroup("startup-group"),
+	}
+}
+
+type StartupFn func(ctx context.Context) error
+
+type StartupGroup struct {
+	startupFns []StartupFn
+
+	shutdownHooks *ShutdownHooks
+	logger        *slog.Logger
+}
+
+func (g *StartupGroup) Add(fn StartupFn) {
+	g.startupFns = append(g.startupFns, fn)
+}
+
+func (g *StartupGroup) Start(ctx context.Context) error {
+	watchForceSignal := func(
+		rootCtx context.Context,
+		signals []os.Signal,
+	) {
+		forceSignal := make(chan os.Signal, 1)
+		signal.Notify(forceSignal, signals...)
+
+		go func() {
+			<-forceSignal
+			g.logger.InfoContext(rootCtx, "Forcing shutdown")
+			os.Exit(1)
+		}()
+	}
+
+	shutdown := func() error {
+		watchForceSignal(ctx, []os.Signal{unix.SIGINT, unix.SIGTERM})
+
+		g.logger.InfoContext(ctx, "Attempting to shut down gracefully")
+		ts := time.Now()
+
+		err := g.shutdownHooks.PerformShutdown(ctx)
+		if err != nil {
+			g.logger.ErrorContext(ctx, "Failed to shut down gracefully", telemetry.ErrAttr(err))
+		}
+
+		g.logger.InfoContext(ctx, "Application stopped",
+			slog.Duration("duration", time.Since(ts)),
+		)
+		return err
+	}
+
+	signalCtx, cancel := signal.NotifyContext(ctx, unix.SIGINT, unix.SIGTERM)
+	defer cancel()
+
+	startupErrors := make(chan error, len(g.startupFns))
+	for _, fn := range g.startupFns {
+		go func(fn StartupFn) {
+			startupErrors <- fn(signalCtx)
+		}(fn)
+	}
+
+	var startupErr error
+	select {
+	case startupErr = <-startupErrors:
+		if startupErr != nil {
+			g.logger.ErrorContext(ctx, "Application startup failed", telemetry.ErrAttr(startupErr))
+		}
+	case <-signalCtx.Done(): // coverage-ignore
+		// We will attempt to shut down in both cases
+		// so doing it once on a next line
+	}
+	return errors.Join(startupErr, shutdown())
+}

--- a/internal/system/lifecycle/startup_group.go
+++ b/internal/system/lifecycle/startup_group.go
@@ -6,7 +6,6 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
-	"time"
 
 	"github.com/gemyago/golang-backend-boilerplate/internal/telemetry"
 	"go.uber.org/dig"
@@ -40,6 +39,9 @@ func (g *StartupGroup) Add(fn StartupFn) {
 	g.startupFns = append(g.startupFns, fn)
 }
 
+// Start runs all startup functions and waits for shutdown signal.
+// It also sets up a listener for forceful shutdown signals to
+// terminate the application immediately if needed.
 func (g *StartupGroup) Start(ctx context.Context) error {
 	watchForceSignal := func(
 		rootCtx context.Context,
@@ -55,24 +57,14 @@ func (g *StartupGroup) Start(ctx context.Context) error {
 		}()
 	}
 
+	shutdownSignals := []os.Signal{unix.SIGINT, unix.SIGTERM}
+
 	shutdown := func() error {
-		watchForceSignal(ctx, []os.Signal{unix.SIGINT, unix.SIGTERM})
-
-		g.logger.InfoContext(ctx, "Attempting to shut down gracefully")
-		ts := time.Now()
-
-		err := g.shutdownHooks.PerformShutdown(ctx)
-		if err != nil {
-			g.logger.ErrorContext(ctx, "Failed to shut down gracefully", telemetry.ErrAttr(err))
-		}
-
-		g.logger.InfoContext(ctx, "Application stopped",
-			slog.Duration("duration", time.Since(ts)),
-		)
-		return err
+		watchForceSignal(ctx, shutdownSignals)
+		return g.shutdownHooks.PerformShutdown(ctx)
 	}
 
-	signalCtx, cancel := signal.NotifyContext(ctx, unix.SIGINT, unix.SIGTERM)
+	signalCtx, cancel := signal.NotifyContext(ctx, shutdownSignals...)
 	defer cancel()
 
 	startupErrors := make(chan error, len(g.startupFns))

--- a/internal/system/lifecycle/startup_group_test.go
+++ b/internal/system/lifecycle/startup_group_test.go
@@ -1,0 +1,226 @@
+package lifecycle
+
+import (
+	"context"
+	"errors"
+	"math/rand/v2"
+	"testing"
+	"time"
+
+	"github.com/gemyago/golang-backend-boilerplate/internal/telemetry"
+	"github.com/jaswdr/faker/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStartupGroupFactory(t *testing.T) {
+	t.Run("NewGroup", func(t *testing.T) {
+		t.Run("should create a new startup group with dependencies", func(t *testing.T) {
+			shutdownHooks := NewTestShutdownHooks()
+			rootLogger := telemetry.RootTestLogger()
+
+			factory := StartupGroupFactory{
+				ShutdownHooks: shutdownHooks,
+				RootLogger:    rootLogger,
+			}
+
+			group := factory.NewGroup()
+
+			require.NotNil(t, group)
+			assert.Equal(t, shutdownHooks, group.shutdownHooks)
+			assert.NotNil(t, group.logger)
+			assert.Empty(t, group.startupFns)
+		})
+	})
+}
+
+func TestStartupGroup(t *testing.T) {
+	fake := faker.New()
+
+	makeTestGroup := func() (*StartupGroup, *ShutdownHooks) {
+		shutdownHooks := NewTestShutdownHooks()
+		factory := StartupGroupFactory{
+			ShutdownHooks: shutdownHooks,
+			RootLogger:    telemetry.RootTestLogger(),
+		}
+		return factory.NewGroup(), shutdownHooks
+	}
+
+	t.Run("Add", func(t *testing.T) {
+		t.Run("should allow adding functions", func(t *testing.T) {
+			group, _ := makeTestGroup()
+
+			functionsCount := 3 + rand.IntN(7)
+			for range functionsCount {
+				group.Add(func(_ context.Context) error { return nil })
+			}
+
+			assert.Len(t, group.startupFns, functionsCount)
+		})
+	})
+
+	t.Run("Start", func(t *testing.T) {
+		t.Run("should execute all startup functions", func(t *testing.T) {
+			group, _ := makeTestGroup()
+
+			executedChan := make(chan int, 3)
+
+			fn1 := func(ctx context.Context) error {
+				executedChan <- 0
+				<-ctx.Done() // Block until cancelled
+				return nil
+			}
+			fn2 := func(ctx context.Context) error {
+				executedChan <- 1
+				<-ctx.Done() // Block until cancelled
+				return nil
+			}
+			fn3 := func(ctx context.Context) error {
+				executedChan <- 2
+				<-ctx.Done() // Block until cancelled
+				return nil
+			}
+
+			group.Add(fn1)
+			group.Add(fn2)
+			group.Add(fn3)
+
+			ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+			defer cancel()
+
+			startDone := make(chan error, 1)
+			go func() {
+				startDone <- group.Start(ctx)
+			}()
+
+			// Now cancel to trigger shutdown
+			cancel()
+
+			// Collect executed functions
+			executed := make([]int, 0, 3)
+			for len(executed) < 3 {
+				select {
+				case idx := <-executedChan:
+					executed = append(executed, idx)
+				case <-time.After(500 * time.Millisecond):
+					t.Fatal("Timeout waiting for startup functions to execute")
+				}
+			}
+
+			err := <-startDone
+			// Can be nil or context.Canceled depending on timing
+			if err != nil {
+				require.ErrorIs(t, err, context.Canceled)
+			}
+			assert.ElementsMatch(t, []int{0, 1, 2}, executed)
+		})
+
+		t.Run("should return error when startup function fails", func(t *testing.T) {
+			group, _ := makeTestGroup()
+
+			wantErr := errors.New(fake.Lorem().Sentence(10))
+			failingFn := func(_ context.Context) error {
+				return wantErr
+			}
+
+			group.Add(failingFn)
+
+			ctx := t.Context()
+
+			err := group.Start(ctx)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, wantErr)
+		})
+
+		t.Run("should call shutdown hooks after startup functions complete", func(t *testing.T) {
+			group, shutdownHooks := makeTestGroup()
+
+			shutdownCalled := false
+			hookName := fake.Lorem().Word()
+			shutdownHooks.Register(hookName, func(_ context.Context) error {
+				shutdownCalled = true
+				return nil
+			})
+
+			startupFn := func(_ context.Context) error {
+				// Return immediately to trigger shutdown
+				return nil
+			}
+			group.Add(startupFn)
+
+			ctx := t.Context()
+
+			err := group.Start(ctx)
+			require.NoError(t, err)
+			assert.True(t, shutdownCalled)
+		})
+
+		t.Run("should include shutdown errors in returned error", func(t *testing.T) {
+			group, shutdownHooks := makeTestGroup()
+
+			shutdownErr := errors.New(fake.Lorem().Sentence(10))
+			hookName := fake.Lorem().Word()
+			shutdownHooks.Register(hookName, func(_ context.Context) error {
+				return shutdownErr
+			})
+
+			startupFn := func(_ context.Context) error {
+				// Return immediately to trigger shutdown
+				return nil
+			}
+			group.Add(startupFn)
+
+			ctx := t.Context()
+
+			err := group.Start(ctx)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, shutdownErr)
+		})
+
+		t.Run("should include both startup and shutdown errors", func(t *testing.T) {
+			group, shutdownHooks := makeTestGroup()
+
+			startupErr := errors.New(fake.Lorem().Sentence(10))
+			shutdownErr := errors.New(fake.Lorem().Sentence(10))
+
+			hookName := fake.Lorem().Word()
+			shutdownHooks.Register(hookName, func(_ context.Context) error {
+				return shutdownErr
+			})
+
+			failingStartupFn := func(_ context.Context) error {
+				return startupErr
+			}
+			group.Add(failingStartupFn)
+
+			ctx := t.Context()
+
+			err := group.Start(ctx)
+			require.Error(t, err)
+			require.ErrorIs(t, err, startupErr)
+			require.ErrorIs(t, err, shutdownErr)
+		})
+
+		t.Run("should properly shutdown when startup function returns immediately", func(t *testing.T) {
+			group, shutdownHooks := makeTestGroup()
+
+			shutdownCalled := false
+			hookName := fake.Lorem().Word()
+			shutdownHooks.Register(hookName, func(_ context.Context) error {
+				shutdownCalled = true
+				return nil
+			})
+
+			// Add a startup function that returns immediately (simulating startup completion)
+			group.Add(func(_ context.Context) error {
+				return nil // Return immediately to trigger shutdown
+			})
+
+			ctx := t.Context()
+
+			err := group.Start(ctx)
+			require.NoError(t, err)
+			assert.True(t, shutdownCalled, "shutdown hooks should be called after startup function completes")
+		})
+	})
+}

--- a/internal/system/lifecycle/testing.go
+++ b/internal/system/lifecycle/testing.go
@@ -1,6 +1,6 @@
 //go:build !release
 
-package shutdown
+package lifecycle
 
 import (
 	"time"
@@ -10,9 +10,9 @@ import (
 
 const defaultTestShutdownTimeout = 30 * time.Second
 
-// NewTestHooks constructor for shutdown Hooks that can be used in tests.
-func NewTestHooks() *Hooks {
-	return NewHooks(HooksDeps{
+// NewTestShutdownHooks constructor for shutdown Hooks that can be used in tests.
+func NewTestShutdownHooks() *ShutdownHooks {
+	return NewShutdownHooks(ShutdownHooksDeps{
 		RootLogger:              telemetry.RootTestLogger(),
 		GracefulShutdownTimeout: defaultTestShutdownTimeout,
 	})

--- a/internal/wireup.go
+++ b/internal/wireup.go
@@ -56,9 +56,9 @@ func Setup(
 			ident.NewDefaultGenerator,
 			di.ProvideImplementation[*ident.DefaultGenerator, ident.Generator],
 
+			lifecycle.NewShutdownHooks,
 			// We can't directly use shutdown hooks in telemetry, since telemetry is used everywhere.
 			// This is a good place to register the implementation.
-			lifecycle.NewShutdownHooks,
 			di.ProvideImplementation[*lifecycle.ShutdownHooks, telemetry.ShutdownHooks],
 		),
 

--- a/internal/wireup.go
+++ b/internal/wireup.go
@@ -11,7 +11,7 @@ import (
 	"github.com/gemyago/golang-backend-boilerplate/internal/infrastructure"
 	"github.com/gemyago/golang-backend-boilerplate/internal/system/apptime"
 	"github.com/gemyago/golang-backend-boilerplate/internal/system/ident"
-	"github.com/gemyago/golang-backend-boilerplate/internal/system/shutdown"
+	"github.com/gemyago/golang-backend-boilerplate/internal/system/lifecycle"
 	"github.com/gemyago/golang-backend-boilerplate/internal/telemetry"
 	"github.com/spf13/viper"
 	otellog "go.opentelemetry.io/otel/log"
@@ -58,8 +58,8 @@ func Setup(
 
 			// We can't directly use shutdown hooks in telemetry, since telemetry is used everywhere.
 			// This is a good place to register the implementation.
-			shutdown.NewHooks,
-			di.ProvideImplementation[*shutdown.Hooks, telemetry.ShutdownHooks],
+			lifecycle.NewShutdownHooks,
+			di.ProvideImplementation[*lifecycle.ShutdownHooks, telemetry.ShutdownHooks],
 		),
 
 		config.Provide(container, cfg),


### PR DESCRIPTION
* Move shutdown hooks to internal/system/lifecycle package
* Add startup group for coordinated service initialization
* Replace errgroup with sync.WaitGroup for parallel shutdown hooks
* Add comprehensive test coverage for shutdown hook scenarios