### PR TITLE
Refactor: Move User Queries to Application Layer

### DIFF
--- a/internal/app/db.go
+++ b/internal/app/db.go
@@ -1,0 +1,10 @@
+package app
+
+import (
+	"context"
+	"database/sql"
+)
+
+type Queryer interface {
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+}

--- a/internal/app/users_queries.go
+++ b/internal/app/users_queries.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 
 	"go.uber.org/dig"
@@ -11,12 +12,15 @@ import (
 // Controllers and other consumers use this directly.
 // Follows "accept interface, return struct" principle.
 type UserQueries struct {
-	usersRepo UsersRepository
-	logger    *slog.Logger
+	usersRepo       UsersRepository
+	logger          *slog.Logger
+	databaseQuerier Queryer
 }
 
 type UserQueriesDeps struct {
 	dig.In
+
+	Queryer
 
 	UsersRepo  UsersRepository
 	RootLogger *slog.Logger
@@ -26,23 +30,51 @@ type UserQueriesDeps struct {
 // This follows "accept interface, return struct" principle.
 func NewUserQueries(deps UserQueriesDeps) *UserQueries {
 	return &UserQueries{
-		usersRepo: deps.UsersRepo,
-		logger:    deps.RootLogger.WithGroup("app.user-queries"),
+		usersRepo:       deps.UsersRepo,
+		logger:          deps.RootLogger.WithGroup("app.user-queries"),
+		databaseQuerier: deps.Queryer,
 	}
 }
 
 func (q *UserQueries) GetUserByID(ctx context.Context, userID string) (*User, error) {
 	user, err := q.usersRepo.GetUserByID(ctx, userID)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get user by ID: %w", err)
 	}
 	return user, nil
 }
 
 func (q *UserQueries) ListUsers(ctx context.Context) ([]*User, error) {
-	users, err := q.usersRepo.ListUsers(ctx)
+	query := `
+		SELECT id, name, email, created_at, updated_at
+		FROM users
+		ORDER BY created_at ASC
+	`
+	rows, err := q.databaseQuerier.QueryContext(ctx, query)
 	if err != nil {
 		return nil, err
 	}
+	defer rows.Close()
+
+	var users []*User
+	for rows.Next() {
+		user := &User{}
+		scanErr := rows.Scan(
+			&user.ID,
+			&user.Name,
+			&user.Email,
+			&user.CreatedAt,
+			&user.UpdatedAt,
+		)
+		if scanErr != nil {
+			return nil, scanErr
+		}
+		users = append(users, user)
+	}
+
+	if rowsErr := rows.Err(); rowsErr != nil {
+		return nil, rowsErr
+	}
+
 	return users, nil
 }

--- a/internal/app/users_queries_test.go
+++ b/internal/app/users_queries_test.go
@@ -1,229 +1,145 @@
-package app
+package app_test
 
 import (
-	"context"
 	"errors"
 	"testing"
-	"time"
 
-	"log/slog"
-
+	"github.com/gemyago/golang-backend-boilerplate/internal/app"
+	"github.com/gemyago/golang-backend-boilerplate/internal/infrastructure"
+	"github.com/gemyago/golang-backend-boilerplate/internal/system/apptime"
+	"github.com/gemyago/golang-backend-boilerplate/internal/system/ident"
+	"github.com/gemyago/golang-backend-boilerplate/internal/telemetry"
+	"github.com/jaswdr/faker/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-type flexibleMockUsersRepository struct {
-	getUserByIDFn func(context.Context, string) (*User, error)
-	listUsersFn   func(context.Context) ([]*User, error)
-}
-
-func (m *flexibleMockUsersRepository) CreateUser(_ context.Context, _ User) error {
-	return nil
-}
-
-func (m *flexibleMockUsersRepository) UpdateUser(_ context.Context, _ User) error {
-	return nil
-}
-
-func (m *flexibleMockUsersRepository) DeleteUser(_ context.Context, _ string) error {
-	return nil
-}
-
-func (m *flexibleMockUsersRepository) GetUserByID(ctx context.Context, userID string) (*User, error) {
-	if m.getUserByIDFn != nil {
-		return m.getUserByIDFn(ctx, userID)
-	}
-	return nil, errors.New("not implemented")
-}
-
-func (m *flexibleMockUsersRepository) GetUserByEmail(_ context.Context, _ string) (*User, error) {
-	return nil, errors.New("not found")
-}
-
-func (m *flexibleMockUsersRepository) ListUsers(ctx context.Context) ([]*User, error) {
-	if m.listUsersFn != nil {
-		return m.listUsersFn(ctx)
-	}
-	return nil, errors.New("not implemented")
-}
-
 func TestUserQueries(t *testing.T) {
 	t.Parallel()
 
-	t.Run("NewUserQueries", func(t *testing.T) {
-		t.Parallel()
+	fake := faker.New()
 
-		deps := makeMockDeps()
-		queries := NewUserQueries(deps)
+	type mockDeps struct {
+		DB              *infrastructure.Database
+		Time            apptime.Provider
+		UserQueriesDeps app.UserQueriesDeps
+	}
 
-		require.NotNil(t, queries)
-		require.NotNil(t, queries.usersRepo)
-		require.NotNil(t, queries.logger)
-	})
+	makeMockDeps := func() mockDeps {
+		mockTime := apptime.NewMockProvider()
+		db := infrastructure.NewTestDatabase(t)
+		return mockDeps{
+			Time: mockTime,
+			DB:   db,
+			UserQueriesDeps: app.UserQueriesDeps{
+				Queryer: db,
+				UsersRepo: infrastructure.NewUsersRepository(infrastructure.UsersRepositoryDeps{
+					DB:    db,
+					Time:  mockTime,
+					IDGen: ident.NewMockGenerator(),
+				}),
+				RootLogger: telemetry.RootTestLogger(),
+			},
+		}
+	}
 
 	t.Run("GetUserByID", func(t *testing.T) {
 		t.Parallel()
 
-		t.Run("happy path", func(t *testing.T) {
+		t.Run("get existing user", func(t *testing.T) {
 			t.Parallel()
+			deps := makeMockDeps()
 
-			now := time.Now()
-			expectedUser := &User{
-				ID:        "123",
-				Name:      "John Doe",
-				Email:     "john@example.com",
-				CreatedAt: now,
-				UpdatedAt: now,
-			}
+			expectedUser := app.NewRandomUser(fake)
 
-			mock := &flexibleMockUsersRepository{
-				getUserByIDFn: func(_ context.Context, id string) (*User, error) {
-					require.Equal(t, "123", id)
-					return expectedUser, nil
-				},
-			}
+			queries := app.NewUserQueries(deps.UserQueriesDeps)
+			require.NoError(t, deps.UserQueriesDeps.UsersRepo.CreateUser(t.Context(), *expectedUser))
 
-			deps := UserQueriesDeps{
-				UsersRepo:  mock,
-				RootLogger: slog.Default(),
-			}
-			queries := NewUserQueries(deps)
-
-			user, err := queries.GetUserByID(context.Background(), "123")
+			user, err := queries.GetUserByID(t.Context(), expectedUser.ID)
 			require.NoError(t, err)
-			require.Equal(t, expectedUser, user)
+			require.Equal(t, expectedUser.ID, user.ID)
 		})
 
-		t.Run("not found", func(t *testing.T) {
+		t.Run("get user error", func(t *testing.T) {
 			t.Parallel()
 
-			mock := &flexibleMockUsersRepository{
-				getUserByIDFn: func(_ context.Context, id string) (*User, error) {
-					require.Equal(t, "nonexistent", id)
-					return nil, NewErrNotFound("user", id)
-				},
-			}
+			deps := makeMockDeps()
+			queries := app.NewUserQueries(deps.UserQueriesDeps)
 
-			deps := UserQueriesDeps{
-				UsersRepo:  mock,
-				RootLogger: slog.Default(),
-			}
-			queries := NewUserQueries(deps)
-
-			_, err := queries.GetUserByID(context.Background(), "nonexistent")
-			var errNotFound *NotFoundError
-			require.ErrorAs(t, err, &errNotFound)
-			assert.Equal(t, "user", errNotFound.Resource)
-		})
-		t.Run("repository error", func(t *testing.T) {
-			t.Parallel()
-
-			expectedErr := errors.New("database connection failed")
-
-			mock := &flexibleMockUsersRepository{
-				getUserByIDFn: func(_ context.Context, id string) (*User, error) {
-					require.Equal(t, "123", id)
-					return nil, expectedErr
-				},
-			}
-
-			deps := UserQueriesDeps{
-				UsersRepo:  mock,
-				RootLogger: slog.Default(),
-			}
-			queries := NewUserQueries(deps)
-
-			_, err := queries.GetUserByID(context.Background(), "123")
-			require.ErrorIs(t, err, expectedErr)
+			user, err := queries.GetUserByID(t.Context(), fake.UUID().V4())
+			require.Error(t, err)
+			require.Nil(t, user)
 		})
 	})
 
 	t.Run("ListUsers", func(t *testing.T) {
-		t.Parallel()
+		t.Run("should return all users", func(t *testing.T) {
+			ctx := t.Context()
 
-		t.Run("happy path", func(t *testing.T) {
-			t.Parallel()
+			// Given
+			deps := makeMockDeps()
+			queries := app.NewUserQueries(deps.UserQueriesDeps)
+			mockNow := apptime.MockProviderValue(deps.Time)
 
-			expectedUsers := []*User{
-				{
-					ID:        "1",
-					Name:      "User 1",
-					Email:     "user1@example.com",
-					CreatedAt: time.Now(),
-					UpdatedAt: time.Now(),
-				},
-				{
-					ID:        "2",
-					Name:      "User 2",
-					Email:     "user2@example.com",
-					CreatedAt: time.Now(),
-					UpdatedAt: time.Now(),
-				},
-			}
+			// Create multiple users
+			user1 := app.NewRandomUser(fake, app.WithUserTimestamps(mockNow, mockNow))
+			user2 := app.NewRandomUser(fake, app.WithUserTimestamps(mockNow, mockNow))
+			user3 := app.NewRandomUser(fake, app.WithUserTimestamps(mockNow, mockNow))
 
-			mock := &flexibleMockUsersRepository{
-				listUsersFn: func(_ context.Context) ([]*User, error) {
-					return expectedUsers, nil
-				},
-			}
-
-			deps := UserQueriesDeps{
-				UsersRepo:  mock,
-				RootLogger: slog.Default(),
-			}
-			queries := NewUserQueries(deps)
-
-			users, err := queries.ListUsers(context.Background())
+			err := errors.Join(
+				deps.UserQueriesDeps.UsersRepo.CreateUser(ctx, *user1),
+				deps.UserQueriesDeps.UsersRepo.CreateUser(ctx, *user2),
+				deps.UserQueriesDeps.UsersRepo.CreateUser(ctx, *user3),
+			)
 			require.NoError(t, err)
-			require.Equal(t, expectedUsers, users)
+
+			// When
+			users, err := queries.ListUsers(ctx)
+
+			// Then
+			require.NoError(t, err)
+			require.Len(t, users, 3)
+
+			// Verify all users are returned (order may vary, so check by content)
+			userMap := make(map[string]*app.User)
+			for _, u := range users {
+				userMap[u.ID] = u
+			}
+
+			assert.Equal(t, user1, userMap[user1.ID])
+			assert.Equal(t, user2, userMap[user2.ID])
+			assert.Equal(t, user3, userMap[user3.ID])
 		})
+		t.Run("should return empty slice if no users", func(t *testing.T) {
+			ctx := t.Context()
 
-		t.Run("empty", func(t *testing.T) {
-			t.Parallel()
+			// Given
+			deps := makeMockDeps()
+			queries := app.NewUserQueries(deps.UserQueriesDeps)
 
-			mock := &flexibleMockUsersRepository{
-				listUsersFn: func(_ context.Context) ([]*User, error) {
-					return []*User{}, nil
-				},
-			}
+			// When
+			users, err := queries.ListUsers(ctx)
 
-			deps := UserQueriesDeps{
-				UsersRepo:  mock,
-				RootLogger: slog.Default(),
-			}
-			queries := NewUserQueries(deps)
-
-			users, err := queries.ListUsers(context.Background())
+			// Then
 			require.NoError(t, err)
 			require.Empty(t, users)
 		})
+		t.Run("should error for database failures", func(t *testing.T) {
+			ctx := t.Context()
 
-		t.Run("repository error", func(t *testing.T) {
-			t.Parallel()
+			// Given
+			deps := makeMockDeps()
+			queries := app.NewUserQueries(deps.UserQueriesDeps)
 
-			expectedErr := errors.New("database query failed")
+			// Close the database to simulate failure
+			deps.DB.Close()
 
-			mock := &flexibleMockUsersRepository{
-				listUsersFn: func(_ context.Context) ([]*User, error) {
-					return nil, expectedErr
-				},
-			}
+			// When
+			users, err := queries.ListUsers(ctx)
 
-			deps := UserQueriesDeps{
-				UsersRepo:  mock,
-				RootLogger: slog.Default(),
-			}
-			queries := NewUserQueries(deps)
-
-			_, err := queries.ListUsers(context.Background())
-			require.ErrorIs(t, err, expectedErr)
+			// Then
+			require.Error(t, err)
+			require.Nil(t, users)
 		})
 	})
-}
-
-func makeMockDeps() UserQueriesDeps {
-	return UserQueriesDeps{
-		UsersRepo:  &flexibleMockUsersRepository{},
-		RootLogger: slog.Default(),
-	}
 }

--- a/internal/app/users_repository.go
+++ b/internal/app/users_repository.go
@@ -22,5 +22,4 @@ type UsersRepository interface {
 	DeleteUser(ctx context.Context, userID string) error
 	GetUserByID(ctx context.Context, userID string) (*User, error)
 	GetUserByEmail(ctx context.Context, email string) (*User, error)
-	ListUsers(ctx context.Context) ([]*User, error)
 }

--- a/internal/app/users_testing.go
+++ b/internal/app/users_testing.go
@@ -18,8 +18,8 @@ func WithUserID(id string) UserOption {
 
 func WithUserTimestamps(createdAt, updatedAt time.Time) UserOption {
 	return func(u *User) {
-		u.CreatedAt = createdAt
-		u.UpdatedAt = updatedAt
+		u.CreatedAt = createdAt.Truncate(time.Millisecond)
+		u.UpdatedAt = updatedAt.Truncate(time.Millisecond)
 	}
 }
 
@@ -31,9 +31,11 @@ func WithUserEmail(email string) UserOption {
 
 func NewRandomUser(fake faker.Faker, opts ...UserOption) *User {
 	user := &User{
-		ID:    fake.RandomStringWithLength(10),
-		Name:  fake.Person().Name(),
-		Email: fake.Internet().Email(),
+		ID:        fake.RandomStringWithLength(10),
+		Name:      fake.Person().Name(),
+		Email:     fake.Internet().Email(),
+		CreatedAt: fake.Time().Past(),
+		UpdatedAt: fake.Time().Recent(),
 	}
 	for _, opt := range opts {
 		opt(user)

--- a/internal/infrastructure/database.go
+++ b/internal/infrastructure/database.go
@@ -19,6 +19,14 @@ type Database struct {
 	instance *sql.DB
 }
 
+func (db *Database) QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
+	return db.instance.QueryContext(ctx, query, args...)
+}
+
+func (db *Database) Close() error {
+	return db.instance.Close()
+}
+
 type DatabaseDeps struct {
 	dig.In
 

--- a/internal/infrastructure/database_testing.go
+++ b/internal/infrastructure/database_testing.go
@@ -12,9 +12,9 @@ import (
 	tracenoop "go.opentelemetry.io/otel/trace/noop"
 )
 
-type testDatabaseOpts func(deps *DatabaseDeps)
+type TestDatabaseOpts func(deps *DatabaseDeps)
 
-func newTestDatabase(t *testing.T, opts ...testDatabaseOpts) *Database {
+func NewTestDatabase(t *testing.T, opts ...TestDatabaseOpts) *Database {
 	t.Helper()
 
 	cfg := config.New()

--- a/internal/infrastructure/pets_repository_test.go
+++ b/internal/infrastructure/pets_repository_test.go
@@ -12,7 +12,7 @@ import (
 func TestPetsRepository(t *testing.T) {
 	makeMockDeps := func(t *testing.T) petsRepositoryDeps {
 		return petsRepositoryDeps{
-			DB:   newTestDatabase(t),
+			DB:   NewTestDatabase(t),
 			Time: apptime.NewMockProvider(),
 		}
 	}
@@ -24,8 +24,8 @@ func TestPetsRepository(t *testing.T) {
 			// Given
 			deps := makeMockDeps(t)
 			repo := newPetsRepository(deps)
-			usersDeps := usersRepositoryDeps{DB: deps.DB, Time: deps.Time}
-			usersRepo := newUsersRepository(usersDeps)
+			usersDeps := UsersRepositoryDeps{DB: deps.DB, Time: deps.Time}
+			usersRepo := NewUsersRepository(usersDeps)
 			fake := faker.New()
 			user := NewRandomUser(fake)
 			err := usersRepo.CreateUser(ctx, *user)
@@ -44,8 +44,8 @@ func TestPetsRepository(t *testing.T) {
 			// Given
 			deps := makeMockDeps(t)
 			repo := newPetsRepository(deps)
-			usersDeps := usersRepositoryDeps{DB: deps.DB, Time: deps.Time}
-			usersRepo := newUsersRepository(usersDeps)
+			usersDeps := UsersRepositoryDeps{DB: deps.DB, Time: deps.Time}
+			usersRepo := NewUsersRepository(usersDeps)
 			fake := faker.New()
 			user := NewRandomUser(fake)
 			err := usersRepo.CreateUser(ctx, *user)
@@ -69,8 +69,8 @@ func TestPetsRepository(t *testing.T) {
 			// Given
 			deps := makeMockDeps(t)
 			repo := newPetsRepository(deps)
-			usersDeps := usersRepositoryDeps{DB: deps.DB, Time: deps.Time}
-			usersRepo := newUsersRepository(usersDeps)
+			usersDeps := UsersRepositoryDeps{DB: deps.DB, Time: deps.Time}
+			usersRepo := NewUsersRepository(usersDeps)
 			fake := faker.New()
 			user := NewRandomUser(fake)
 			err := usersRepo.CreateUser(ctx, *user)
@@ -125,8 +125,8 @@ func TestPetsRepository(t *testing.T) {
 			userID := fake.RandomStringWithLength(10)
 
 			// Create multiple pets for the user
-			usersDeps := usersRepositoryDeps{DB: deps.DB, Time: deps.Time}
-			usersRepo := newUsersRepository(usersDeps)
+			usersDeps := UsersRepositoryDeps{DB: deps.DB, Time: deps.Time}
+			usersRepo := NewUsersRepository(usersDeps)
 			user := NewRandomUser(fake)
 			user.ID = userID
 			err := usersRepo.CreateUser(ctx, *user)
@@ -193,8 +193,8 @@ func TestPetsRepository(t *testing.T) {
 			// Given
 			deps := makeMockDeps(t)
 			repo := newPetsRepository(deps)
-			usersDeps := usersRepositoryDeps{DB: deps.DB, Time: deps.Time}
-			usersRepo := newUsersRepository(usersDeps)
+			usersDeps := UsersRepositoryDeps{DB: deps.DB, Time: deps.Time}
+			usersRepo := NewUsersRepository(usersDeps)
 			fake := faker.New()
 			user := NewRandomUser(fake)
 			err := usersRepo.CreateUser(ctx, *user)
@@ -258,8 +258,8 @@ func TestPetsRepository(t *testing.T) {
 			// Given
 			deps := makeMockDeps(t)
 			petsRepo := newPetsRepository(deps)
-			usersDeps := usersRepositoryDeps{DB: deps.DB, Time: deps.Time}
-			usersRepo := newUsersRepository(usersDeps)
+			usersDeps := UsersRepositoryDeps{DB: deps.DB, Time: deps.Time}
+			usersRepo := NewUsersRepository(usersDeps)
 			fake := faker.New()
 			mockNow := apptime.MockProviderValue(deps.Time)
 

--- a/internal/infrastructure/register.go
+++ b/internal/infrastructure/register.go
@@ -14,7 +14,8 @@ func Register(rootCtx context.Context, container *dig.Container) error {
 	return di.ProvideAll(container,
 		httpclient.NewClientFactory,
 		newDBProvider(rootCtx),
-		di.ProvideFactoryAs[app.UsersRepository](newUsersRepository),
+		di.ProvideImplementation[*Database, app.Queryer],
+		di.ProvideFactoryAs[app.UsersRepository](NewUsersRepository),
 		di.ProvideFactoryAs[app.PetsRepository](newPetsRepository),
 		di.ProvideFactoryAs[app.PetstoreClient](func(deps petstore.ClientDeps) *petstore.Client {
 			return petstore.NewClient(deps)

--- a/internal/infrastructure/users_repository.go
+++ b/internal/infrastructure/users_repository.go
@@ -12,16 +12,16 @@ import (
 	_ "modernc.org/sqlite" // SQLite driver
 )
 
-type sqliteUsersRepository struct {
+type SQLiteUsersRepository struct {
 	db    *sql.DB
 	time  apptime.Provider
 	idGen ident.Generator
 }
 
 // Ensure sqliteUsersRepository implements app.UsersRepository.
-var _ app.UsersRepository = (*sqliteUsersRepository)(nil)
+var _ app.UsersRepository = (*SQLiteUsersRepository)(nil)
 
-type usersRepositoryDeps struct {
+type UsersRepositoryDeps struct {
 	dig.In
 
 	DB    *Database
@@ -29,15 +29,15 @@ type usersRepositoryDeps struct {
 	IDGen ident.Generator
 }
 
-func newUsersRepository(deps usersRepositoryDeps) *sqliteUsersRepository {
-	return &sqliteUsersRepository{
+func NewUsersRepository(deps UsersRepositoryDeps) *SQLiteUsersRepository {
+	return &SQLiteUsersRepository{
 		db:    deps.DB.instance,
 		time:  deps.Time,
 		idGen: deps.IDGen,
 	}
 }
 
-func (r *sqliteUsersRepository) ensureRowsUpdated(result sql.Result) error {
+func (r *SQLiteUsersRepository) ensureRowsUpdated(result sql.Result) error {
 	rowsAffected, err := result.RowsAffected()
 	if err != nil {
 		return err
@@ -48,7 +48,7 @@ func (r *sqliteUsersRepository) ensureRowsUpdated(result sql.Result) error {
 	return nil
 }
 
-func (r *sqliteUsersRepository) CreateUser(ctx context.Context, user app.User) error {
+func (r *SQLiteUsersRepository) CreateUser(ctx context.Context, user app.User) error {
 	// Generate UUID if not provided
 	if user.ID == "" {
 		user.ID = r.idGen.MustNewV7().String()
@@ -68,7 +68,7 @@ func (r *sqliteUsersRepository) CreateUser(ctx context.Context, user app.User) e
 	return err
 }
 
-func (r *sqliteUsersRepository) UpdateUser(ctx context.Context, user app.User) error {
+func (r *SQLiteUsersRepository) UpdateUser(ctx context.Context, user app.User) error {
 	// Update updated_at timestamp to current time
 	user.UpdatedAt = r.time.Now()
 
@@ -94,7 +94,7 @@ func (r *sqliteUsersRepository) UpdateUser(ctx context.Context, user app.User) e
 	return nil
 }
 
-func (r *sqliteUsersRepository) DeleteUser(ctx context.Context, userID string) error {
+func (r *SQLiteUsersRepository) DeleteUser(ctx context.Context, userID string) error {
 	query := `
 		DELETE FROM users
 		WHERE id = ?
@@ -114,7 +114,7 @@ func (r *sqliteUsersRepository) DeleteUser(ctx context.Context, userID string) e
 	return nil
 }
 
-func (r *sqliteUsersRepository) GetUserByID(ctx context.Context, userID string) (*app.User, error) {
+func (r *SQLiteUsersRepository) GetUserByID(ctx context.Context, userID string) (*app.User, error) {
 	query := `
 		SELECT id, name, email, created_at, updated_at
 		FROM users
@@ -137,7 +137,7 @@ func (r *sqliteUsersRepository) GetUserByID(ctx context.Context, userID string) 
 	return user, nil
 }
 
-func (r *sqliteUsersRepository) GetUserByEmail(ctx context.Context, email string) (*app.User, error) {
+func (r *SQLiteUsersRepository) GetUserByEmail(ctx context.Context, email string) (*app.User, error) {
 	query := `
 		SELECT id, name, email, created_at, updated_at
 		FROM users
@@ -158,39 +158,4 @@ func (r *sqliteUsersRepository) GetUserByEmail(ctx context.Context, email string
 		return nil, err
 	}
 	return user, nil
-}
-
-func (r *sqliteUsersRepository) ListUsers(ctx context.Context) ([]*app.User, error) {
-	query := `
-		SELECT id, name, email, created_at, updated_at
-		FROM users
-		ORDER BY created_at ASC
-	`
-	rows, err := r.db.QueryContext(ctx, query)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	var users []*app.User
-	for rows.Next() {
-		user := &app.User{}
-		scanErr := rows.Scan(
-			&user.ID,
-			&user.Name,
-			&user.Email,
-			&user.CreatedAt,
-			&user.UpdatedAt,
-		)
-		if scanErr != nil {
-			return nil, scanErr
-		}
-		users = append(users, user)
-	}
-
-	if rowsErr := rows.Err(); rowsErr != nil {
-		return nil, rowsErr
-	}
-
-	return users, nil
 }

--- a/internal/infrastructure/users_repository_test.go
+++ b/internal/infrastructure/users_repository_test.go
@@ -1,7 +1,6 @@
 package infrastructure
 
 import (
-	"errors"
 	"testing"
 	"time"
 
@@ -14,9 +13,9 @@ import (
 )
 
 func TestUsersRepository(t *testing.T) {
-	makeMockDeps := func(t *testing.T) usersRepositoryDeps {
-		return usersRepositoryDeps{
-			DB:    newTestDatabase(t),
+	makeMockDeps := func(t *testing.T) UsersRepositoryDeps {
+		return UsersRepositoryDeps{
+			DB:    NewTestDatabase(t),
 			Time:  apptime.NewMockProvider(),
 			IDGen: ident.NewMockGenerator(),
 		}
@@ -30,7 +29,7 @@ func TestUsersRepository(t *testing.T) {
 
 			// Given
 			deps := makeMockDeps(t)
-			repo := newUsersRepository(deps)
+			repo := NewUsersRepository(deps)
 			mockNow := apptime.MockProviderValue(deps.Time)
 
 			user := NewRandomUser(fake, WithUserTimestamps(mockNow, mockNow))
@@ -61,7 +60,7 @@ func TestUsersRepository(t *testing.T) {
 
 			// Given
 			deps := makeMockDeps(t)
-			repo := newUsersRepository(deps)
+			repo := NewUsersRepository(deps)
 
 			email := fake.Internet().Email()
 			user1 := NewRandomUser(fake, WithUserEmail(email))
@@ -85,7 +84,7 @@ func TestUsersRepository(t *testing.T) {
 
 			// Given
 			deps := makeMockDeps(t)
-			repo := newUsersRepository(deps)
+			repo := NewUsersRepository(deps)
 
 			user := NewRandomUser(fake, WithUserID("")) // Empty ID to trigger UUID generation
 
@@ -113,7 +112,7 @@ func TestUsersRepository(t *testing.T) {
 
 			// Given
 			deps := makeMockDeps(t)
-			repo := newUsersRepository(deps)
+			repo := NewUsersRepository(deps)
 			mockNow := apptime.MockProviderValue(deps.Time)
 
 			user := NewRandomUser(fake, WithUserTimestamps(mockNow, mockNow))
@@ -152,7 +151,7 @@ func TestUsersRepository(t *testing.T) {
 
 			// Given
 			deps := makeMockDeps(t)
-			repo := newUsersRepository(deps)
+			repo := NewUsersRepository(deps)
 
 			user := NewRandomUser(fake)
 
@@ -172,7 +171,7 @@ func TestUsersRepository(t *testing.T) {
 
 			// Given
 			deps := makeMockDeps(t)
-			repo := newUsersRepository(deps)
+			repo := NewUsersRepository(deps)
 
 			user1 := NewRandomUser(fake)
 			err := repo.CreateUser(ctx, *user1)
@@ -203,7 +202,7 @@ func TestUsersRepository(t *testing.T) {
 
 			// Given
 			deps := makeMockDeps(t)
-			repo := newUsersRepository(deps)
+			repo := NewUsersRepository(deps)
 			mockNow := apptime.MockProviderValue(deps.Time)
 
 			user := NewRandomUser(fake, WithUserTimestamps(mockNow, mockNow))
@@ -233,7 +232,7 @@ func TestUsersRepository(t *testing.T) {
 
 			// Given
 			deps := makeMockDeps(t)
-			repo := newUsersRepository(deps)
+			repo := NewUsersRepository(deps)
 
 			// When
 			err := repo.DeleteUser(ctx, "non-existent-id")
@@ -251,7 +250,7 @@ func TestUsersRepository(t *testing.T) {
 
 			// Given
 			deps := makeMockDeps(t)
-			repo := newUsersRepository(deps)
+			repo := NewUsersRepository(deps)
 
 			// Close DB
 			deps.DB.instance.Close()
@@ -272,7 +271,7 @@ func TestUsersRepository(t *testing.T) {
 
 			// Given
 			deps := makeMockDeps(t)
-			repo := newUsersRepository(deps)
+			repo := NewUsersRepository(deps)
 			mockNow := apptime.MockProviderValue(deps.Time)
 
 			user := NewRandomUser(fake, WithUserTimestamps(mockNow, mockNow))
@@ -303,7 +302,7 @@ func TestUsersRepository(t *testing.T) {
 
 			// Given
 			deps := makeMockDeps(t)
-			repo := newUsersRepository(deps)
+			repo := NewUsersRepository(deps)
 			mockNow := apptime.MockProviderValue(deps.Time)
 
 			user := NewRandomUser(fake, WithUserTimestamps(mockNow, mockNow))
@@ -324,7 +323,7 @@ func TestUsersRepository(t *testing.T) {
 
 			// Given
 			deps := makeMockDeps(t)
-			repo := newUsersRepository(deps)
+			repo := NewUsersRepository(deps)
 			mockNow := apptime.MockProviderValue(deps.Time)
 
 			user := NewRandomUser(fake, WithUserTimestamps(mockNow, mockNow))
@@ -350,7 +349,7 @@ func TestUsersRepository(t *testing.T) {
 
 			// Given
 			deps := makeMockDeps(t)
-			repo := newUsersRepository(deps)
+			repo := NewUsersRepository(deps)
 			mockNow := apptime.MockProviderValue(deps.Time)
 
 			user := NewRandomUser(fake, WithUserTimestamps(mockNow, mockNow))
@@ -371,7 +370,7 @@ func TestUsersRepository(t *testing.T) {
 
 			// Given
 			deps := makeMockDeps(t)
-			repo := newUsersRepository(deps)
+			repo := NewUsersRepository(deps)
 
 			// When
 			retrievedUser, err := repo.GetUserByID(ctx, "non-existent-id")
@@ -390,7 +389,7 @@ func TestUsersRepository(t *testing.T) {
 
 			// Given
 			deps := makeMockDeps(t)
-			repo := newUsersRepository(deps)
+			repo := NewUsersRepository(deps)
 			// Close the DB to simulate failure
 			deps.DB.instance.Close()
 
@@ -411,7 +410,7 @@ func TestUsersRepository(t *testing.T) {
 
 			// Given
 			deps := makeMockDeps(t)
-			repo := newUsersRepository(deps)
+			repo := NewUsersRepository(deps)
 			mockNow := apptime.MockProviderValue(deps.Time)
 
 			user := NewRandomUser(fake, WithUserTimestamps(mockNow, mockNow))
@@ -432,7 +431,7 @@ func TestUsersRepository(t *testing.T) {
 
 			// Given
 			deps := makeMockDeps(t)
-			repo := newUsersRepository(deps)
+			repo := NewUsersRepository(deps)
 
 			// When
 			retrievedUser, err := repo.GetUserByEmail(ctx, "nonexistent@example.com")
@@ -451,7 +450,7 @@ func TestUsersRepository(t *testing.T) {
 
 			// Given
 			deps := makeMockDeps(t)
-			repo := newUsersRepository(deps)
+			repo := NewUsersRepository(deps)
 			// Close the DB to simulate failure
 			deps.DB.instance.Close()
 
@@ -461,81 +460,6 @@ func TestUsersRepository(t *testing.T) {
 			// Then
 			require.Error(t, err)
 			assert.Nil(t, retrievedUser)
-		})
-	})
-
-	t.Run("ListUsers", func(t *testing.T) {
-		fake := faker.New()
-
-		t.Run("should return all users", func(t *testing.T) {
-			ctx := t.Context()
-
-			// Given
-			deps := makeMockDeps(t)
-			repo := newUsersRepository(deps)
-			mockNow := apptime.MockProviderValue(deps.Time)
-
-			// Create multiple users
-			user1 := NewRandomUser(fake, WithUserTimestamps(mockNow, mockNow))
-			user2 := NewRandomUser(fake, WithUserTimestamps(mockNow, mockNow))
-			user3 := NewRandomUser(fake, WithUserTimestamps(mockNow, mockNow))
-
-			err := errors.Join(
-				repo.CreateUser(ctx, *user1),
-				repo.CreateUser(ctx, *user2),
-				repo.CreateUser(ctx, *user3),
-			)
-			require.NoError(t, err)
-
-			// When
-			users, err := repo.ListUsers(ctx)
-
-			// Then
-			require.NoError(t, err)
-			require.Len(t, users, 3)
-
-			// Verify all users are returned (order may vary, so check by content)
-			userMap := make(map[string]*app.User)
-			for _, u := range users {
-				userMap[u.ID] = u
-			}
-
-			assert.Equal(t, user1, userMap[user1.ID])
-			assert.Equal(t, user2, userMap[user2.ID])
-			assert.Equal(t, user3, userMap[user3.ID])
-		})
-
-		t.Run("should return empty slice when no users", func(t *testing.T) {
-			ctx := t.Context()
-
-			// Given
-			deps := makeMockDeps(t)
-			repo := newUsersRepository(deps)
-
-			// When
-			users, err := repo.ListUsers(ctx)
-
-			// Then
-			require.NoError(t, err)
-			assert.Empty(t, users)
-		})
-
-		t.Run("should return error for database failure", func(t *testing.T) {
-			ctx := t.Context()
-
-			// Given
-			deps := makeMockDeps(t)
-			repo := newUsersRepository(deps)
-
-			// Close DB
-			deps.DB.instance.Close()
-
-			// When
-			users, err := repo.ListUsers(ctx)
-
-			// Then
-			require.Error(t, err)
-			assert.Nil(t, users)
 		})
 	})
 }


### PR DESCRIPTION
- Move user listing query from infrastructure to application layer
- Rename repository types to follow Go naming conventions
- Add Queryer interface for database abstraction
- Update tests to use real database instead of mocks
- Add database methods to Database struct